### PR TITLE
chore: use npm @catalyst-team/cache ^0.2.0 and bump to v0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catalyst-team/poly-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "license": "MIT",
   "description": "TypeScript SDK for Polymarket - prediction markets trading, smart money analysis, and market data",
@@ -54,7 +54,7 @@
   "dependencies": {
     "@polymarket/clob-client": "^5.1.3",
     "@polymarket/real-time-data-client": "^1.4.0",
-    "@catalyst-team/cache": "workspace:*",
+    "@catalyst-team/cache": "^0.2.0",
     "@types/ws": "^8.18.1",
     "bottleneck": "^2.19.5",
     "ethers": "5",

--- a/scripts/dip-arb/redeem-positions.ts
+++ b/scripts/dip-arb/redeem-positions.ts
@@ -38,6 +38,11 @@ async function main() {
   console.log('╚══════════════════════════════════════════════════════════╝');
   console.log('');
 
+  if (!PRIVATE_KEY) {
+    console.error('Error: PRIVATE_KEY environment variable is required');
+    process.exit(1);
+  }
+
   // Initialize SDK
   console.log('Initializing SDK...');
   const sdk = new PolymarketSDK({


### PR DESCRIPTION
## Summary
- Update cache dependency from `workspace:*` to `^0.2.0` (npm package)
- Fix TypeScript error in redeem-positions.ts (PRIVATE_KEY validation)
- Bump version to 0.4.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)