### PR TITLE
feat(v2): Polymarket CLOB V2 SDK 完整迁移 (constants + trading + wrap + approvals + calldata + 3 P0 fixes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@catalyst-team/cache": "^0.2.0",
     "@polymarket/builder-relayer-client": "^0.0.8",
     "@polymarket/builder-signing-sdk": "^0.0.8",
-    "@polymarket/clob-client": "^5.1.3",
     "@polymarket/clob-client-v2": "1.0.3",
     "@types/ws": "^8.18.1",
     "bottleneck": "^2.19.5",

--- a/package.json
+++ b/package.json
@@ -53,10 +53,11 @@
     "access": "public"
   },
   "dependencies": {
-    "@polymarket/clob-client": "^5.1.3",
+    "@catalyst-team/cache": "^0.2.0",
     "@polymarket/builder-relayer-client": "^0.0.8",
     "@polymarket/builder-signing-sdk": "^0.0.8",
-    "@catalyst-team/cache": "^0.2.0",
+    "@polymarket/clob-client": "^5.1.3",
+    "@polymarket/clob-client-v2": "1.0.3",
     "@types/ws": "^8.18.1",
     "bottleneck": "^2.19.5",
     "ethers": "5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@polymarket/builder-signing-sdk':
         specifier: ^0.0.8
         version: 0.0.8
-      '@polymarket/clob-client':
-        specifier: ^5.1.3
-        version: 5.2.0(typescript@5.9.3)
       '@polymarket/clob-client-v2':
         specifier: 1.0.3
         version: 1.0.3(typescript@5.9.3)
@@ -471,14 +468,6 @@ packages:
   '@polymarket/clob-client-v2@1.0.3':
     resolution: {integrity: sha512-dA2q/IoDh2u0CdEBRSvmbdC/+e+oxbRz1KeuydL3Yv3oGSudG0PAyyK7n/I80n/RV+5ZwreUKjb0pYT1aadVtg==}
 
-  '@polymarket/clob-client@5.2.0':
-    resolution: {integrity: sha512-bKtShP0nSmWgFdG2rNgUOefFFmKUY10Z/u/ZYiNp3SKSs2XntPCI+aevVaA3/lVTJuQLXk+5B5/QjhFkmkCvXg==}
-    engines: {node: '>=20.10'}
-
-  '@polymarket/order-utils@3.0.1':
-    resolution: {integrity: sha512-XVcVladfGtC/VmboMkcszqYs82rvath/0XFWqzIFfq8O4atVOU8ykPOGJ2ZfodBPcXETzL+2u1rcepLMLKu9AQ==}
-    engines: {node: '>=20.10', yarn: '>=1'}
-
   '@rollup/rollup-android-arm-eabi@4.55.1':
     resolution: {integrity: sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==}
     cpu: [arm]
@@ -698,9 +687,6 @@ packages:
 
   brorand@1.1.0:
     resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
-
-  browser-or-node@2.1.1:
-    resolution: {integrity: sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg==}
 
   browser-or-node@3.0.0:
     resolution: {integrity: sha512-iczIdVJzGEYhP5DqQxYM9Hh7Ztpqqi+CXZpSmX8ALFs9ecXkQIeqRyM6TfxEfMVpwhl3dSuDvxdzzo9sUOIVBQ==}
@@ -1639,37 +1625,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@polymarket/clob-client@5.2.0(typescript@5.9.3)':
-    dependencies:
-      '@ethersproject/providers': 5.8.0
-      '@ethersproject/units': 5.8.0
-      '@ethersproject/wallet': 5.8.0
-      '@polymarket/builder-signing-sdk': 0.0.8
-      '@polymarket/order-utils': 3.0.1(typescript@5.9.3)
-      axios: 1.13.2
-      browser-or-node: 2.1.1
-      ethers: 5.8.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@polymarket/order-utils@3.0.1(typescript@5.9.3)':
-    dependencies:
-      '@ethersproject/providers': 5.8.0
-      '@ethersproject/wallet': 5.8.0
-      ethers: 5.8.0
-      tslib: 2.8.1
-      viem: 2.44.1(typescript@5.9.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - zod
-
   '@rollup/rollup-android-arm-eabi@4.55.1':
     optional: true
 
@@ -1848,8 +1803,6 @@ snapshots:
   bottleneck@2.19.5: {}
 
   brorand@1.1.0: {}
-
-  browser-or-node@2.1.1: {}
 
   browser-or-node@3.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,18 @@ importers:
       '@catalyst-team/cache':
         specifier: ^0.2.0
         version: 0.2.0
+      '@polymarket/builder-relayer-client':
+        specifier: ^0.0.8
+        version: 0.0.8
+      '@polymarket/builder-signing-sdk':
+        specifier: ^0.0.8
+        version: 0.0.8
       '@polymarket/clob-client':
         specifier: ^5.1.3
         version: 5.2.0(typescript@5.9.3)
-      '@polymarket/real-time-data-client':
-        specifier: ^1.4.0
-        version: 1.4.0
+      '@polymarket/clob-client-v2':
+        specifier: 1.0.3
+        version: 1.0.3(typescript@5.9.3)
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -453,8 +459,17 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@polymarket/builder-abstract-signer@0.0.1':
+    resolution: {integrity: sha512-XuuxQQcXYtqQce8slhqiJQti1lVPr+xXC7M3lbetmNnsc9tlYdYRnojE+tcniCHg7VQ6dokcIu0eLYDtM5vdvQ==}
+
+  '@polymarket/builder-relayer-client@0.0.8':
+    resolution: {integrity: sha512-l9bQvghlMn8FIknw4+QAJ1dA1pyTCHMr0vQff1EKt7aGo8wXKa68FloxKc9PoBF35s7zZ6fsy+hZiRpSaYqvYg==}
+
   '@polymarket/builder-signing-sdk@0.0.8':
     resolution: {integrity: sha512-rZLCFxEdYahl5FiJmhe22RDXysS1ibFJlWz4NT0s3itJRYq3XJzXXHXEZkAQplU+nIS1IlbbKjA4zDQaeCyYtg==}
+
+  '@polymarket/clob-client-v2@1.0.3':
+    resolution: {integrity: sha512-dA2q/IoDh2u0CdEBRSvmbdC/+e+oxbRz1KeuydL3Yv3oGSudG0PAyyK7n/I80n/RV+5ZwreUKjb0pYT1aadVtg==}
 
   '@polymarket/clob-client@5.2.0':
     resolution: {integrity: sha512-bKtShP0nSmWgFdG2rNgUOefFFmKUY10Z/u/ZYiNp3SKSs2XntPCI+aevVaA3/lVTJuQLXk+5B5/QjhFkmkCvXg==}
@@ -463,9 +478,6 @@ packages:
   '@polymarket/order-utils@3.0.1':
     resolution: {integrity: sha512-XVcVladfGtC/VmboMkcszqYs82rvath/0XFWqzIFfq8O4atVOU8ykPOGJ2ZfodBPcXETzL+2u1rcepLMLKu9AQ==}
     engines: {node: '>=20.10', yarn: '>=1'}
-
-  '@polymarket/real-time-data-client@1.4.0':
-    resolution: {integrity: sha512-227JTQyhAT9C4Re+9Q2HsxRK+T0pse0BZmTIQdOSXJgdRvYh8e+bRZbW7drPGaKI+LbFU8gjl4CJI/jrv7LAIw==}
 
   '@rollup/rollup-android-arm-eabi@4.55.1':
     resolution: {integrity: sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==}
@@ -656,12 +668,18 @@ packages:
   aes-js@3.0.0:
     resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
 
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@0.27.2:
+    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
 
   axios@1.13.2:
     resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
@@ -683,6 +701,12 @@ packages:
 
   browser-or-node@2.1.1:
     resolution: {integrity: sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg==}
+
+  browser-or-node@3.0.0:
+    resolution: {integrity: sha512-iczIdVJzGEYhP5DqQxYM9Hh7Ztpqqi+CXZpSmX8ALFs9ecXkQIeqRyM6TfxEfMVpwhl3dSuDvxdzzo9sUOIVBQ==}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -708,6 +732,9 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -728,6 +755,10 @@ packages:
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
+
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
+    engines: {node: '>=0.3.1'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -864,6 +895,9 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -892,6 +926,14 @@ packages:
 
   ox@0.11.3:
     resolution: {integrity: sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  ox@0.14.20:
+    resolution: {integrity: sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -941,6 +983,13 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -968,6 +1017,13 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  ts-node@9.1.1:
+    resolution: {integrity: sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=2.7'
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -989,6 +1045,14 @@ packages:
 
   viem@2.44.1:
     resolution: {integrity: sha512-wfQda7PIJeF9hWiGKV628AfBwyYxyoc89OcgF4s4/chs2PY8ibUA7IG+DWdU4oAkjhHm9w47w1m2dwwOPBU+ng==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  viem@2.48.8:
+    resolution: {integrity: sha512-Xj3Nrt66SKtn06kczU91ELn9Difr84ZM5A62BTlaisT5lpgt058i2mBkfMZCXHGb1ocOLjzC2ztPhD0Lvky7uQ==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -1096,6 +1160,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
 
 snapshots:
 
@@ -1521,6 +1589,33 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@polymarket/builder-abstract-signer@0.0.1':
+    dependencies:
+      ethers: 5.8.0
+      ts-node: 9.1.1(typescript@5.9.3)
+      typescript: 5.9.3
+      viem: 2.44.1(typescript@5.9.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  '@polymarket/builder-relayer-client@0.0.8':
+    dependencies:
+      '@polymarket/builder-abstract-signer': 0.0.1
+      '@polymarket/builder-signing-sdk': 0.0.8
+      axios: 0.27.2
+      browser-or-node: 3.0.0
+      ethers: 5.8.0
+      tsx: 4.21.0
+      typescript: 5.9.3
+      viem: 2.44.1(typescript@5.9.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+      - zod
+
   '@polymarket/builder-signing-sdk@0.0.8':
     dependencies:
       '@types/node': 18.19.130
@@ -1528,6 +1623,21 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - debug
+
+  '@polymarket/clob-client-v2@1.0.3(typescript@5.9.3)':
+    dependencies:
+      '@ethersproject/providers': 5.8.0
+      '@ethersproject/wallet': 5.8.0
+      axios: 1.13.2
+      browser-or-node: 3.0.0
+      tslib: 2.8.1
+      viem: 2.48.8(typescript@5.9.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - typescript
+      - utf-8-validate
+      - zod
 
   '@polymarket/clob-client@5.2.0(typescript@5.9.3)':
     dependencies:
@@ -1559,15 +1669,6 @@ snapshots:
       - typescript
       - utf-8-validate
       - zod
-
-  '@polymarket/real-time-data-client@1.4.0':
-    dependencies:
-      isomorphic-ws: 5.0.0(ws@8.19.0)
-      tslib: 2.8.1
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   '@rollup/rollup-android-arm-eabi@4.55.1':
     optional: true
@@ -1717,9 +1818,18 @@ snapshots:
 
   aes-js@3.0.0: {}
 
+  arg@4.1.3: {}
+
   assertion-error@2.0.1: {}
 
   asynckit@0.4.0: {}
+
+  axios@0.27.2:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+    transitivePeerDependencies:
+      - debug
 
   axios@1.13.2:
     dependencies:
@@ -1740,6 +1850,10 @@ snapshots:
   brorand@1.1.0: {}
 
   browser-or-node@2.1.1: {}
+
+  browser-or-node@3.0.0: {}
+
+  buffer-from@1.1.2: {}
 
   cac@6.7.14: {}
 
@@ -1764,6 +1878,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  create-require@1.1.1: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -1773,6 +1889,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   denque@2.1.0: {}
+
+  diff@4.0.4: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -2002,6 +2120,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  make-error@1.3.6: {}
+
   math-intrinsics@1.1.0: {}
 
   mime-db@1.52.0: {}
@@ -2019,6 +2139,21 @@ snapshots:
   nanoid@3.3.11: {}
 
   ox@0.11.3(typescript@5.9.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.20(typescript@5.9.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -2092,6 +2227,13 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
   stackback@0.0.2: {}
 
   standard-as-callback@2.1.0: {}
@@ -2107,6 +2249,16 @@ snapshots:
   tinyrainbow@1.2.0: {}
 
   tinyspy@3.0.2: {}
+
+  ts-node@9.1.1(typescript@5.9.3):
+    dependencies:
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      source-map-support: 0.5.21
+      typescript: 5.9.3
+      yn: 3.1.1
 
   tslib@2.8.1: {}
 
@@ -2132,6 +2284,23 @@ snapshots:
       abitype: 1.2.3(typescript@5.9.3)
       isows: 1.0.7(ws@8.18.3)
       ox: 0.11.3(typescript@5.9.3)
+      ws: 8.18.3
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.48.8(typescript@5.9.3):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)
+      isows: 1.0.7(ws@8.18.3)
+      ox: 0.14.20(typescript@5.9.3)
       ws: 8.18.3
     optionalDependencies:
       typescript: 5.9.3
@@ -2212,3 +2381,5 @@ snapshots:
   ws@8.18.3: {}
 
   ws@8.19.0: {}
+
+  yn@3.1.1: {}

--- a/scripts/ordermanager/bug20-deep-analysis.ts
+++ b/scripts/ordermanager/bug20-deep-analysis.ts
@@ -26,7 +26,7 @@
  * 余额要求：~$6 USDC.e（4 个场景 × $1.5）
  */
 
-import { ClobClient, Chain } from '@polymarket/clob-client';
+import { ClobClient, Chain } from '@polymarket/clob-client-v2';
 import { Wallet } from 'ethers';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -237,7 +237,8 @@ async function main() {
 
   // Get token info from CLOB API
   const wallet = new Wallet(PRIVATE_KEY);
-  const clobClient = new ClobClient(CLOB_HOST, Chain.POLYGON, wallet);
+  // V2 SDK: options-bag constructor; `chain` replaces V1 `chainId`.
+  const clobClient = new ClobClient({ host: CLOB_HOST, chain: Chain.POLYGON, signer: wallet });
   const clobMarket = await clobClient.getMarket(testMarket.conditionId);
 
   if (!clobMarket?.tokens || clobMarket.tokens.length < 2) {

--- a/scripts/ordermanager/bug24-tokenid-test.ts
+++ b/scripts/ordermanager/bug24-tokenid-test.ts
@@ -24,7 +24,7 @@
  * Balance Required: ~$5 USDC.e
  */
 
-import { ClobClient, Chain } from '@polymarket/clob-client';
+import { ClobClient, Chain } from '@polymarket/clob-client-v2';
 import { Wallet } from 'ethers';
 import { OrderManager, type FillEvent } from '../../src/services/order-manager.js';
 import { RealtimeServiceV2 } from '../../src/services/realtime-service-v2.js';
@@ -208,8 +208,8 @@ async function main() {
   const address = await wallet.getAddress();
   log(`Wallet: ${address}`);
 
-  // Initialize CLOB client
-  const clobClient = new ClobClient(CLOB_HOST, Chain.POLYGON, wallet);
+  // Initialize CLOB client (V2 SDK: options-bag constructor).
+  const clobClient = new ClobClient({ host: CLOB_HOST, chain: Chain.POLYGON, signer: wallet });
 
   // Get API credentials
   const creds = await clobClient.createOrDeriveApiCreds();

--- a/scripts/ordermanager/test-market-order-lifecycle.ts
+++ b/scripts/ordermanager/test-market-order-lifecycle.ts
@@ -17,7 +17,7 @@
  *   PRIVATE_KEY=0x... npx tsx scripts/ordermanager/test-market-order-lifecycle.ts --fak-only
  */
 
-import { ClobClient, Chain } from '@polymarket/clob-client';
+import { ClobClient, Chain } from '@polymarket/clob-client-v2';
 import { Wallet } from 'ethers';
 import { OrderManager } from '../../src/services/order-manager.js';
 import { GammaApiClient } from '../../src/clients/gamma-api.js';
@@ -140,7 +140,8 @@ async function main() {
 
   // Use CLOB API to get token IDs (they're not in Gamma API response)
   const wallet = new Wallet(PRIVATE_KEY);
-  const clobClient = new ClobClient(CLOB_HOST, Chain.POLYGON, wallet);
+  // V2 SDK: options-bag constructor; `chain` replaces V1 `chainId`.
+  const clobClient = new ClobClient({ host: CLOB_HOST, chain: Chain.POLYGON, signer: wallet });
 
   console.log('   Fetching market details from CLOB API...');
   const clobMarket = await clobClient.getMarket(testMarket.conditionId);

--- a/scripts/test-creds-with-address.ts
+++ b/scripts/test-creds-with-address.ts
@@ -15,10 +15,10 @@
  * 测试流程：
  * 1. 读取保存的 credentials（包含 wallet address）
  * 2. 创建 mock signer，getAddress() 返回保存的地址
- * 3. 直接使用 @polymarket/clob-client 测试 L2 操作
+ * 3. 直接使用 @polymarket/clob-client-v2 测试 L2 操作
  */
 
-import { ClobClient } from '@polymarket/clob-client';
+import { ClobClient } from '@polymarket/clob-client-v2';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 
@@ -73,16 +73,16 @@ async function testWithMockSigner(creds: StoredCredentials): Promise<void> {
 
   try {
     // @ts-ignore - ClobClient 期望 Wallet 类型，但我们传入 mock signer
-    const client = new ClobClient(
-      CLOB_HOST,
-      POLYGON_CHAIN_ID,
-      mockSigner as any,
-      {
+    const client = new ClobClient({
+      host: CLOB_HOST,
+      chain: POLYGON_CHAIN_ID as any,
+      signer: mockSigner as any,
+      creds: {
         key: creds.key,
         secret: creds.secret,
         passphrase: creds.passphrase,
-      }
-    );
+      },
+    });
 
     console.log('✅ CLOB Client 创建成功');
 
@@ -134,7 +134,11 @@ async function testL1Operations(creds: StoredCredentials): Promise<void> {
 
   try {
     // @ts-ignore
-    const client = new ClobClient(CLOB_HOST, POLYGON_CHAIN_ID, mockSigner as any);
+    const client = new ClobClient({
+      host: CLOB_HOST,
+      chain: POLYGON_CHAIN_ID as any,
+      signer: mockSigner as any,
+    });
 
     // 测试 deriveApiKey - 这是 L1 操作，需要 EIP-712 签名
     console.log('📝 测试 L1: deriveApiKey (需要 EIP-712 签名)...');

--- a/scripts/verify-earning-engine-data.ts
+++ b/scripts/verify-earning-engine-data.ts
@@ -18,7 +18,7 @@
  */
 
 import { Wallet } from 'ethers';
-import { ClobClient } from '@polymarket/clob-client';
+import { ClobClient } from '@polymarket/clob-client-v2';
 import { DataApiClient } from '../src/clients/data-api.js';
 import { GammaApiClient } from '../src/clients/gamma-api.js';
 import { RealtimeServiceV2 } from '../src/services/realtime-service-v2.js';
@@ -264,13 +264,12 @@ async function verifyMarketData() {
 
           // Test 3: Get orderbook
           try {
-            const clobClient = new ClobClient(
-              '137',  // Polygon mainnet
-              wallet,
-              {
-                chainId: 137,
-              }
-            );
+            // V2 SDK options-bag constructor (was V1 positional args).
+            const clobClient = new ClobClient({
+              host: 'https://clob.polymarket.com',
+              chain: 137 as any, // Polygon mainnet
+              signer: wallet as any,
+            });
 
             const orderbook = await clobClient.getOrderBook(market.conditionId);
 

--- a/scripts/verify-user-events.ts
+++ b/scripts/verify-user-events.ts
@@ -14,7 +14,7 @@
  */
 
 import { RealtimeServiceV2, UserOrder, UserTrade } from '../src/services/realtime-service-v2.js';
-import { ClobClient } from '@polymarket/clob-client';
+import { ClobClient } from '@polymarket/clob-client-v2';
 import { Wallet } from 'ethers';
 
 // Event tracking
@@ -97,11 +97,11 @@ async function main() {
   // Create CLOB API credentials
   console.log('\n🔐 Creating CLOB API credentials...');
 
-  const clobClient = new ClobClient(
-    'https://clob.polymarket.com',
-    137, // Polygon mainnet
-    wallet
-  );
+  const clobClient = new ClobClient({
+    host: 'https://clob.polymarket.com',
+    chain: 137, // Polygon mainnet
+    signer: wallet,
+  });
 
   // Derive API credentials
   const creds = await clobClient.createOrDeriveApiCreds();

--- a/src/__tests__/unit/v2-authorization.test.ts
+++ b/src/__tests__/unit/v2-authorization.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Unit tests for AuthorizationService V2 spender matrix.
+ *
+ * Stage C of the Polymarket V2 migration switches the approval set:
+ *   - 3 pUSD ERC20 approvals (V2 CTF Exchange, V2 NegRisk Exchange,
+ *     NegRisk Adapter — all the V2 trading rail).
+ *   - 1 USDC.e ERC20 approval to the Collateral Onramp (gateway for
+ *     `wrap(USDC.e → pUSD)`).
+ *   - 3 ERC1155 operator approvals (the same V2 contracts, minus the
+ *     Onramp which never moves CTF tokens).
+ *
+ * Behavioural contract:
+ *   - `checkAllowances()` reports 4 ERC20 rows + 3 ERC1155 rows tagged with
+ *     the correct token + V2 address.
+ *   - `approveAll()` calls `approve()` on the right ERC20 contract for each
+ *     row (pUSD vs USDC.e), then `setApprovalForAll(true)` on Conditional
+ *     Tokens for each operator.
+ *
+ * We mock `ethers.Contract` calls on a per-address basis so no RPC is made.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ethers } from 'ethers';
+
+import { AuthorizationService } from '../../services/authorization-service.js';
+import { POLYGON_CONTRACTS_V2 } from '../../constants/v2-contracts.js';
+
+// Stub ethers contracts: we override only the methods our service calls.
+// Each method tracks invocations on `calls` so we can assert routing.
+interface StubContract {
+  address: string;
+  // ERC20
+  approve?: ReturnType<typeof vi.fn>;
+  allowance?: ReturnType<typeof vi.fn>;
+  balanceOf?: ReturnType<typeof vi.fn>;
+  // ERC1155
+  setApprovalForAll?: ReturnType<typeof vi.fn>;
+  isApprovedForAll?: ReturnType<typeof vi.fn>;
+}
+
+const TX = {
+  wait: async () => ({}),
+};
+
+// Track all approve/setApprovalForAll calls in the order they're submitted.
+type ApproveCall = { token: string; spender: string; amount: string };
+type ErcOpCall = { token: string; operator: string; approved: boolean };
+
+let approveCalls: ApproveCall[];
+let ercOpCalls: ErcOpCall[];
+
+beforeEach(() => {
+  approveCalls = [];
+  ercOpCalls = [];
+});
+
+// Replace ethers.Contract with a per-address router stub.
+const realContract = ethers.Contract;
+beforeEach(() => {
+  // Behaviour we want to vary in individual tests
+  const allowanceFor = new Map<string, ethers.BigNumber>();
+  const isApprovedFor = new Map<string, boolean>();
+
+  // Default: nothing approved, low allowance => approveAll triggers approve()
+  // for every spender.
+  ;(globalThis as any).__allowanceFor = allowanceFor;
+  ;(globalThis as any).__isApprovedFor = isApprovedFor;
+
+  vi.spyOn(ethers, 'Contract').mockImplementation(((
+    addr: string,
+    _abi: any,
+    _signerOrProvider: any
+  ) => {
+    const tokenLabel =
+      addr.toLowerCase() === POLYGON_CONTRACTS_V2.pUSD.toLowerCase()
+        ? 'pUSD'
+        : addr.toLowerCase() === POLYGON_CONTRACTS_V2.usdcE.toLowerCase()
+          ? 'USDC.e'
+          : addr.toLowerCase() ===
+              '0x4D97DCd97eC945f40cF65F87097ACe5EA0476045'.toLowerCase()
+            ? 'CTF'
+            : `unknown(${addr})`;
+
+    const stub: StubContract = { address: addr };
+
+    if (tokenLabel === 'pUSD' || tokenLabel === 'USDC.e') {
+      stub.balanceOf = vi.fn(async (_who: string) =>
+        ethers.utils.parseUnits('100', 6)
+      );
+      stub.allowance = vi.fn(async (_who: string, spender: string) => {
+        const key = `${tokenLabel}:${spender.toLowerCase()}`;
+        return allowanceFor.get(key) ?? ethers.BigNumber.from(0);
+      });
+      stub.approve = vi.fn(async (spender: string, amount: ethers.BigNumber) => {
+        approveCalls.push({
+          token: tokenLabel,
+          spender,
+          amount: amount.toString(),
+        });
+        return { ...TX, hash: '0xapprovetx' };
+      });
+    }
+
+    if (tokenLabel === 'CTF') {
+      stub.isApprovedForAll = vi.fn(async (_who: string, op: string) => {
+        return isApprovedFor.get(op.toLowerCase()) ?? false;
+      });
+      stub.setApprovalForAll = vi.fn(async (op: string, approved: boolean) => {
+        ercOpCalls.push({ token: 'CTF', operator: op, approved });
+        return { ...TX, hash: '0xerc1155tx' };
+      });
+    }
+
+    return stub as unknown as ethers.Contract;
+  }) as any);
+});
+
+function makeService(): AuthorizationService {
+  // A wallet that doesn't need to make RPC calls — provider is set to a
+  // dummy and we override `getGasPrice()` via spy.
+  const provider = {
+    getGasPrice: vi.fn(async () => ethers.BigNumber.from('30000000000')),
+  } as unknown as ethers.providers.Provider;
+
+  // Build a Wallet without provider (we just need the address).
+  const wallet = new ethers.Wallet('0x' + '1'.repeat(64));
+  const svc = new AuthorizationService(wallet, { provider });
+  return svc;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AuthorizationService V2 spender matrix', () => {
+  it('exposes 4 ERC20 rows with correct token tags + V2 addresses', async () => {
+    const svc = makeService();
+    const result = await svc.checkAllowances();
+
+    expect(result.erc20Allowances).toHaveLength(4);
+
+    const byName = new Map(
+      result.erc20Allowances.map((a) => [a.contract, a])
+    );
+    expect(byName.get('V2 CTF Exchange')).toMatchObject({
+      address: POLYGON_CONTRACTS_V2.ctfExchange,
+      token: 'pUSD',
+      approved: false,
+    });
+    expect(byName.get('V2 NegRisk CTF Exchange')).toMatchObject({
+      address: POLYGON_CONTRACTS_V2.negRiskExchange,
+      token: 'pUSD',
+      approved: false,
+    });
+    expect(byName.get('NegRisk Adapter')).toMatchObject({
+      address: POLYGON_CONTRACTS_V2.negRiskAdapter,
+      token: 'pUSD',
+      approved: false,
+    });
+    expect(byName.get('Onramp (USDC.e wrap)')).toMatchObject({
+      address: POLYGON_CONTRACTS_V2.collateralOnramp,
+      token: 'USDC.e',
+      approved: false,
+    });
+  });
+
+  it('exposes 3 ERC1155 rows pointing at V2 exchanges + Adapter', async () => {
+    const svc = makeService();
+    const result = await svc.checkAllowances();
+
+    expect(result.erc1155Approvals).toHaveLength(3);
+
+    const addrs = result.erc1155Approvals.map((r) => r.address);
+    expect(addrs).toEqual([
+      POLYGON_CONTRACTS_V2.ctfExchange,
+      POLYGON_CONTRACTS_V2.negRiskExchange,
+      POLYGON_CONTRACTS_V2.negRiskAdapter,
+    ]);
+
+    // Onramp does NOT need ERC1155 approval — we never want it to move
+    // outcome tokens.
+    expect(addrs).not.toContain(POLYGON_CONTRACTS_V2.collateralOnramp);
+  });
+
+  it('approveAll() routes pUSD approvals to the pUSD ERC20 + USDC.e to USDC.e', async () => {
+    const svc = makeService();
+    const result = await svc.approveAll();
+
+    // 4 ERC20 + 3 ERC1155 = 7 total
+    expect(result.erc20Approvals).toHaveLength(4);
+    expect(result.erc1155Approvals).toHaveLength(3);
+    expect(result.allApproved).toBe(true);
+
+    // Ensure each call hit the right ERC20 contract
+    const pusdCalls = approveCalls.filter((c) => c.token === 'pUSD');
+    const usdceCalls = approveCalls.filter((c) => c.token === 'USDC.e');
+
+    expect(pusdCalls).toHaveLength(3);
+    expect(usdceCalls).toHaveLength(1);
+
+    // pUSD should approve V2 Exchange / V2 NegRisk Exchange / NegRisk Adapter
+    expect(new Set(pusdCalls.map((c) => c.spender))).toEqual(
+      new Set([
+        POLYGON_CONTRACTS_V2.ctfExchange,
+        POLYGON_CONTRACTS_V2.negRiskExchange,
+        POLYGON_CONTRACTS_V2.negRiskAdapter,
+      ])
+    );
+
+    // USDC.e should approve only the Onramp
+    expect(usdceCalls[0].spender).toBe(POLYGON_CONTRACTS_V2.collateralOnramp);
+    // unlimited approval (MaxUint256)
+    expect(usdceCalls[0].amount).toBe(ethers.constants.MaxUint256.toString());
+  });
+
+  it('approveAll() ERC1155 calls hit V2 Exchange + V2 NegRisk + Adapter', async () => {
+    const svc = makeService();
+    await svc.approveAll();
+
+    expect(ercOpCalls).toHaveLength(3);
+    expect(new Set(ercOpCalls.map((c) => c.operator))).toEqual(
+      new Set([
+        POLYGON_CONTRACTS_V2.ctfExchange,
+        POLYGON_CONTRACTS_V2.negRiskExchange,
+        POLYGON_CONTRACTS_V2.negRiskAdapter,
+      ])
+    );
+    expect(ercOpCalls.every((c) => c.approved === true)).toBe(true);
+  });
+
+  it('checkAllowances() flips to tradingReady=true when all 7 rows approved', async () => {
+    // Pre-seed allowances + isApprovedForAll
+    const allowanceFor = (globalThis as any).__allowanceFor as Map<
+      string,
+      ethers.BigNumber
+    >;
+    const isApprovedFor = (globalThis as any).__isApprovedFor as Map<
+      string,
+      boolean
+    >;
+    const HUGE = ethers.utils.parseUnits('1000000000000000', 6); // > 1e12 USDC
+
+    allowanceFor.set(`pUSD:${POLYGON_CONTRACTS_V2.ctfExchange.toLowerCase()}`, HUGE);
+    allowanceFor.set(`pUSD:${POLYGON_CONTRACTS_V2.negRiskExchange.toLowerCase()}`, HUGE);
+    allowanceFor.set(`pUSD:${POLYGON_CONTRACTS_V2.negRiskAdapter.toLowerCase()}`, HUGE);
+    allowanceFor.set(`USDC.e:${POLYGON_CONTRACTS_V2.collateralOnramp.toLowerCase()}`, HUGE);
+    isApprovedFor.set(POLYGON_CONTRACTS_V2.ctfExchange.toLowerCase(), true);
+    isApprovedFor.set(POLYGON_CONTRACTS_V2.negRiskExchange.toLowerCase(), true);
+    isApprovedFor.set(POLYGON_CONTRACTS_V2.negRiskAdapter.toLowerCase(), true);
+
+    const svc = makeService();
+    const result = await svc.checkAllowances();
+    expect(result.tradingReady).toBe(true);
+    expect(result.issues).toHaveLength(0);
+    expect(result.erc20Allowances.every((r) => r.approved)).toBe(true);
+    expect(result.erc1155Approvals.every((r) => r.approved)).toBe(true);
+  });
+
+  it('approveAll() short-circuits already-approved rows (no redundant approve())', async () => {
+    const allowanceFor = (globalThis as any).__allowanceFor as Map<
+      string,
+      ethers.BigNumber
+    >;
+    const isApprovedFor = (globalThis as any).__isApprovedFor as Map<
+      string,
+      boolean
+    >;
+    const HUGE = ethers.utils.parseUnits('1000000000000000', 6);
+
+    // Pre-approve 2 rows; expect approveAll to skip them
+    allowanceFor.set(`pUSD:${POLYGON_CONTRACTS_V2.ctfExchange.toLowerCase()}`, HUGE);
+    isApprovedFor.set(POLYGON_CONTRACTS_V2.ctfExchange.toLowerCase(), true);
+
+    const svc = makeService();
+    await svc.approveAll();
+
+    // 4 ERC20 - 1 already approved = 3 fresh approve() calls
+    expect(approveCalls).toHaveLength(3);
+    // 3 ERC1155 - 1 already approved = 2 fresh setApprovalForAll calls
+    expect(ercOpCalls).toHaveLength(2);
+  });
+
+  it('does not import any V1 contract address into the spender list', async () => {
+    const svc = makeService();
+    const result = await svc.checkAllowances();
+
+    const allAddrs = [
+      ...result.erc20Allowances.map((r) => r.address.toLowerCase()),
+      ...result.erc1155Approvals.map((r) => r.address.toLowerCase()),
+    ];
+
+    // V1 CTF Exchange + V1 NegRisk CTF Exchange addresses
+    expect(allAddrs).not.toContain(
+      '0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E'.toLowerCase()
+    );
+    expect(allAddrs).not.toContain(
+      '0xC5d563A36AE78145C45a50134d48A1215220f80a'.toLowerCase()
+    );
+  });
+});

--- a/src/__tests__/unit/v2-builder-config.test.ts
+++ b/src/__tests__/unit/v2-builder-config.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for V2 builder-code env helper.
+ *
+ * Stage B (PR-B) of the Polymarket V2 migration replaces the legacy HMAC
+ * three-tuple (POLY_BUILDER_API_KEY/SECRET/PASSPHRASE) for *order signing*
+ * with a single bytes32 `builderCode`. The helper sourced from
+ * `src/constants/builder-config.ts` validates the env var format eagerly so
+ * misconfiguration fails at startup rather than silently producing malformed
+ * on-chain orders.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  readBuilderCode,
+  readBuilderCodeOptional,
+} from '../../constants/builder-config.js';
+
+const ENV_KEY = 'POLY_BUILDER_CODE';
+
+describe('V2 builder-config helpers', () => {
+  let prev: string | undefined;
+
+  beforeEach(() => {
+    prev = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (prev === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = prev;
+    }
+  });
+
+  describe('readBuilderCode (strict)', () => {
+    it('returns the code when it matches the bytes32 pattern', () => {
+      const code = '0x' + 'a'.repeat(64);
+      process.env[ENV_KEY] = code;
+      expect(readBuilderCode()).toBe(code);
+    });
+
+    it('accepts mixed-case hex (checksummed-style is fine for bytes32)', () => {
+      const code = '0xAbCdEf' + '0'.repeat(58);
+      process.env[ENV_KEY] = code;
+      expect(readBuilderCode()).toBe(code);
+    });
+
+    it('throws when the env var is unset', () => {
+      expect(() => readBuilderCode()).toThrow(/POLY_BUILDER_CODE/);
+    });
+
+    it('throws when the env var is empty', () => {
+      process.env[ENV_KEY] = '';
+      expect(() => readBuilderCode()).toThrow(/POLY_BUILDER_CODE/);
+    });
+
+    it('throws when the prefix is missing', () => {
+      process.env[ENV_KEY] = 'a'.repeat(64);
+      expect(() => readBuilderCode()).toThrow(/bytes32/);
+    });
+
+    it('throws when the body is too short', () => {
+      process.env[ENV_KEY] = '0x' + 'a'.repeat(63);
+      expect(() => readBuilderCode()).toThrow(/bytes32/);
+    });
+
+    it('throws when the body is too long', () => {
+      process.env[ENV_KEY] = '0x' + 'a'.repeat(65);
+      expect(() => readBuilderCode()).toThrow(/bytes32/);
+    });
+
+    it('throws when the body contains non-hex characters', () => {
+      process.env[ENV_KEY] = '0x' + 'g'.repeat(64);
+      expect(() => readBuilderCode()).toThrow(/bytes32/);
+    });
+
+    it('error message links to the migration plan SSOT', () => {
+      // The message MUST include enough context for a reader to find the
+      // canonical sourcing instructions without grep-spelunking.
+      try {
+        readBuilderCode();
+        throw new Error('expected throw');
+      } catch (err) {
+        expect((err as Error).message).toMatch(/plans\/12/);
+      }
+    });
+  });
+
+  describe('readBuilderCodeOptional', () => {
+    it('returns undefined when the env var is unset', () => {
+      expect(readBuilderCodeOptional()).toBeUndefined();
+    });
+
+    it('returns undefined when the env var is empty', () => {
+      process.env[ENV_KEY] = '';
+      expect(readBuilderCodeOptional()).toBeUndefined();
+    });
+
+    it('returns the code when valid', () => {
+      const code = '0x' + 'b'.repeat(64);
+      process.env[ENV_KEY] = code;
+      expect(readBuilderCodeOptional()).toBe(code);
+    });
+
+    it('throws when set but malformed (does NOT silently degrade)', () => {
+      // A typo in the env should fail loudly even on a read-only path; we
+      // never want a strategy to silently start trading without builder
+      // attribution.
+      process.env[ENV_KEY] = '0xnope';
+      expect(() => readBuilderCodeOptional()).toThrow(/bytes32/);
+    });
+  });
+});

--- a/src/__tests__/unit/v2-calldata-decoder.test.ts
+++ b/src/__tests__/unit/v2-calldata-decoder.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Unit tests for V1 / V2 matchOrders calldata decoder.
+ *
+ * Stage C of the Polymarket V2 migration teaches the decoder about the V2
+ * direct-on-exchange `matchOrders` ABI (selector `0x3c2b4399`, 12-field
+ * SignedOrder tuple) while keeping the V1 FeeModule path
+ * (selector `0x2287e350`, 13-field tuple) for historical-replay scenarios.
+ *
+ * Behavioural contract:
+ *   - V1 calldata → `decodeMatchOrdersCalldata*` returns `version: 1` with
+ *     V1 fields populated (taker is the on-chain value).
+ *   - V2 calldata → returns `version: 2` with V2 fields populated
+ *     (timestamp / metadata / builder), taker forced to zero address.
+ *   - Unknown selector / malformed calldata → null (no exception).
+ *   - V1-only and V2-only entry points return null when the calldata
+ *     belongs to the other version.
+ *
+ * Fixtures are constructed in-test so the test stays self-contained and
+ * tracks any future ABI tweaks.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ethers } from 'ethers';
+
+import {
+  decodeMatchOrdersCalldata,
+  decodeMatchOrdersCalldataV1,
+  decodeMatchOrdersCalldataV2,
+  MATCH_ORDERS_SELECTOR_V1,
+  MATCH_ORDERS_SELECTOR_V2,
+  OrderSide,
+} from '../../utils/calldata-decoder.js';
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+const V1_TUPLE =
+  'tuple(uint256 salt, address maker, address signer, address taker, uint256 tokenId, uint256 makerAmount, uint256 takerAmount, uint256 expiration, uint256 nonce, uint256 feeRateBps, uint8 side, uint8 signatureType, bytes signature)';
+
+const V1_IFACE = new ethers.utils.Interface([
+  `function matchOrders(${V1_TUPLE} takerOrder, ${V1_TUPLE}[] makerOrders, uint256 takerFillAmount, uint256 makerFillAmount, uint256[] makerFillAmounts, uint256 takerFeeAmount, uint256[] makerFeeAmounts)`,
+]);
+
+const V2_TUPLE =
+  'tuple(uint256 salt, address maker, address signer, uint256 tokenId, uint256 makerAmount, uint256 takerAmount, uint8 side, uint8 signatureType, uint256 timestamp, bytes32 metadata, bytes32 builder, bytes signature)';
+
+const V2_IFACE = new ethers.utils.Interface([
+  `function matchOrders(bytes32 contextHash, ${V2_TUPLE} takerOrder, ${V2_TUPLE}[] makerOrders, uint256 takerFillAmount, uint256[] makerFillAmounts, uint256 takerFeeAmount, uint256[] makerFeeAmounts)`,
+]);
+
+// Lower-case addresses for fixtures so we can compare directly.
+const TAKER_MAKER_V1 = '0x000000000000000000000000000000000000aaaa';
+const MAKER_MAKER_V1 = '0x000000000000000000000000000000000000bbbb';
+const TAKER_MAKER_V2 = '0x000000000000000000000000000000000000cccc';
+const MAKER_MAKER_V2 = '0x000000000000000000000000000000000000dddd';
+
+const METADATA_HEX = '0x' + '11'.repeat(32);
+const BUILDER_HEX = '0x' + '22'.repeat(32);
+
+function buildV1Calldata(): string {
+  const taker = {
+    salt: 1n,
+    maker: TAKER_MAKER_V1,
+    signer: TAKER_MAKER_V1,
+    taker: '0x0000000000000000000000000000000000000000',
+    tokenId: 12345n,
+    makerAmount: 1_000_000n,
+    takerAmount: 2_000_000n,
+    expiration: 0n,
+    nonce: 0n,
+    feeRateBps: 100n,
+    side: 0,
+    signatureType: 0,
+    signature: '0x',
+  };
+  const maker = {
+    ...taker,
+    maker: MAKER_MAKER_V1,
+    signer: MAKER_MAKER_V1,
+    side: 1,
+  };
+  return V1_IFACE.encodeFunctionData('matchOrders', [
+    taker,
+    [maker],
+    1_000_000n,
+    2_000_000n,
+    [1_000_000n],
+    0n,
+    [0n],
+  ]);
+}
+
+function buildV2Calldata(): string {
+  const taker = {
+    salt: 99n,
+    maker: TAKER_MAKER_V2,
+    signer: TAKER_MAKER_V2,
+    tokenId: 7777n,
+    makerAmount: 5_000_000n,
+    takerAmount: 8_000_000n,
+    side: 0,
+    signatureType: 2,
+    timestamp: 1714435200000n,
+    metadata: METADATA_HEX,
+    builder: BUILDER_HEX,
+    signature: '0xabcd',
+  };
+  const maker = {
+    ...taker,
+    maker: MAKER_MAKER_V2,
+    signer: MAKER_MAKER_V2,
+    side: 1,
+  };
+  return V2_IFACE.encodeFunctionData('matchOrders', [
+    '0x' + 'ff'.repeat(32),
+    taker,
+    [maker],
+    5_000_000n,
+    [5_000_000n],
+    0n,
+    [0n],
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('calldata-decoder selectors', () => {
+  it('V1 selector is 0x2287e350', () => {
+    expect(MATCH_ORDERS_SELECTOR_V1).toBe('0x2287e350');
+  });
+
+  it('V2 selector is 0x3c2b4399', () => {
+    expect(MATCH_ORDERS_SELECTOR_V2).toBe('0x3c2b4399');
+  });
+
+  it('V1 fixture starts with the V1 selector', () => {
+    expect(buildV1Calldata().slice(0, 10)).toBe(MATCH_ORDERS_SELECTOR_V1);
+  });
+
+  it('V2 fixture starts with the V2 selector', () => {
+    expect(buildV2Calldata().slice(0, 10)).toBe(MATCH_ORDERS_SELECTOR_V2);
+  });
+});
+
+describe('decodeMatchOrdersCalldataV1', () => {
+  it('decodes V1 fixture into V1 fields', () => {
+    const decoded = decodeMatchOrdersCalldataV1(buildV1Calldata());
+    expect(decoded).not.toBeNull();
+    expect(decoded!.version).toBe(1);
+    expect(decoded!.takerOrder.maker).toBe(TAKER_MAKER_V1);
+    expect(decoded!.takerOrder.signer).toBe(TAKER_MAKER_V1);
+    expect(decoded!.takerOrder.taker).toBe(
+      '0x0000000000000000000000000000000000000000'
+    );
+    expect(decoded!.takerOrder.tokenId).toBe('12345');
+    expect(decoded!.takerOrder.makerAmount).toBe('1000000');
+    expect(decoded!.takerOrder.takerAmount).toBe('2000000');
+    expect(decoded!.takerOrder.side).toBe(OrderSide.BUY);
+
+    expect(decoded!.makerOrders).toHaveLength(1);
+    expect(decoded!.makerOrders[0].maker).toBe(MAKER_MAKER_V1);
+    expect(decoded!.makerOrders[0].side).toBe(OrderSide.SELL);
+
+    expect(decoded!.takerFillAmount).toBe('1000000');
+    expect(decoded!.makerFillAmounts).toEqual(['1000000']);
+  });
+
+  it('returns null for V2 calldata (cross-version isolation)', () => {
+    const decoded = decodeMatchOrdersCalldataV1(buildV2Calldata());
+    expect(decoded).toBeNull();
+  });
+
+  it('returns null for unknown selector', () => {
+    expect(decodeMatchOrdersCalldataV1('0xdeadbeef')).toBeNull();
+  });
+
+  it('returns null for malformed body', () => {
+    expect(
+      decodeMatchOrdersCalldataV1(MATCH_ORDERS_SELECTOR_V1 + 'aabbcc')
+    ).toBeNull();
+  });
+});
+
+describe('decodeMatchOrdersCalldataV2', () => {
+  it('decodes V2 fixture into V2 fields with timestamp/metadata/builder', () => {
+    const decoded = decodeMatchOrdersCalldataV2(buildV2Calldata());
+    expect(decoded).not.toBeNull();
+    expect(decoded!.version).toBe(2);
+
+    const taker = decoded!.takerOrder as any;
+    expect(taker.maker).toBe(TAKER_MAKER_V2);
+    expect(taker.signer).toBe(TAKER_MAKER_V2);
+    expect(taker.tokenId).toBe('7777');
+    expect(taker.makerAmount).toBe('5000000');
+    expect(taker.takerAmount).toBe('8000000');
+    expect(taker.side).toBe(OrderSide.BUY);
+    expect(taker.timestamp).toBe('1714435200000');
+    expect(taker.metadata).toBe(METADATA_HEX);
+    expect(taker.builder).toBe(BUILDER_HEX);
+    // V2 has no on-chain taker — decoder forces zero address
+    expect(taker.taker).toBe('0x0000000000000000000000000000000000000000');
+
+    expect(decoded!.makerOrders).toHaveLength(1);
+    expect(decoded!.makerOrders[0].maker).toBe(MAKER_MAKER_V2);
+    expect(decoded!.makerOrders[0].side).toBe(OrderSide.SELL);
+
+    expect(decoded!.takerFillAmount).toBe('5000000');
+    expect(decoded!.makerFillAmounts).toEqual(['5000000']);
+  });
+
+  it('returns null for V1 calldata (cross-version isolation)', () => {
+    const decoded = decodeMatchOrdersCalldataV2(buildV1Calldata());
+    expect(decoded).toBeNull();
+  });
+
+  it('returns null for unknown selector', () => {
+    expect(decodeMatchOrdersCalldataV2('0xcafebabe')).toBeNull();
+  });
+});
+
+describe('decodeMatchOrdersCalldata (auto-detect)', () => {
+  it('routes V2 calldata to the V2 decoder', () => {
+    const decoded = decodeMatchOrdersCalldata(buildV2Calldata());
+    expect(decoded).not.toBeNull();
+    expect(decoded!.version).toBe(2);
+    expect((decoded!.takerOrder as any).timestamp).toBe('1714435200000');
+  });
+
+  it('falls back to V1 decoder for V1 calldata', () => {
+    const decoded = decodeMatchOrdersCalldata(buildV1Calldata());
+    expect(decoded).not.toBeNull();
+    expect(decoded!.version).toBe(1);
+    expect(decoded!.takerOrder.taker).toBe(
+      '0x0000000000000000000000000000000000000000'
+    );
+  });
+
+  it('returns null for unknown calldata without throwing', () => {
+    expect(decodeMatchOrdersCalldata('0xdeadbeef')).toBeNull();
+    expect(decodeMatchOrdersCalldata('0x' + 'ab'.repeat(100))).toBeNull();
+  });
+
+  it('does NOT silently accept V1 fixture as V2 (selector check is strict)', () => {
+    // V1 calldata has the V1 selector; auto-detect must NOT misdetect as V2
+    const decoded = decodeMatchOrdersCalldata(buildV1Calldata());
+    expect(decoded!.version).toBe(1);
+    expect((decoded!.takerOrder as any).timestamp).toBeUndefined();
+  });
+
+  it('handles V2 decode failure gracefully (selector match + bad body → null)', () => {
+    const corrupt = MATCH_ORDERS_SELECTOR_V2 + 'aabb';
+    expect(decodeMatchOrdersCalldata(corrupt)).toBeNull();
+  });
+});

--- a/src/__tests__/unit/v2-relayer-token-routing.test.ts
+++ b/src/__tests__/unit/v2-relayer-token-routing.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Unit tests for V2 Relayer collateral-token routing.
+ *
+ * After the 2026-04-28 V2 cutover, trading collateral is `pUSD`. The relayer
+ * helpers (`approveUsdc`, `transferUsdc`, `split`, `merge`, `redeem`,
+ * `redeemBatch`) used to hardcode V1 USDC.e for the collateral argument /
+ * `to` field, which would revert against V2 markets. The fix introduces a
+ * `CollateralToken` parameter on each function (default `'pUSD'`) that
+ * routes the call to the correct ERC-20 contract via
+ * `POLYGON_CONTRACTS_V2.{pUSD,usdcE}`.
+ *
+ * These tests assert the routing behaviour by capturing the encoded
+ * transaction the service emits to a mocked relay client.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ethers, BigNumber } from 'ethers';
+import { POLYGON_CONTRACTS_V2 } from '../../constants/v2-contracts.js';
+import {
+  CTF_CONTRACT,
+  NEG_RISK_ADAPTER,
+} from '../../clients/ctf-client.js';
+
+// ---------------------------------------------------------------------------
+// Module mocks (mirrors v2-relayer-wrap.test.ts pattern)
+// ---------------------------------------------------------------------------
+
+let capturedExecute: { txs: any[] } | null = null;
+
+vi.mock('@polymarket/builder-relayer-client', () => {
+  class RelayClient {
+    contractConfig = {
+      SafeContracts: {
+        SafeFactory: '0xaacFeEa03eb1561C4e67d661e40682Bd20E3541b',
+      },
+    };
+    constructor(_url: string, _chainId: number, _signer: any, _bc: any) {}
+    async getDeployed(_addr: string) {
+      return true;
+    }
+    async deploy() {
+      return { wait: async () => ({ state: 'STATE_CONFIRMED', transactionHash: '0x00' }) };
+    }
+    async execute(transactions: any[]) {
+      capturedExecute = { txs: transactions };
+      return {
+        wait: async () => ({
+          state: 'STATE_CONFIRMED',
+          transactionHash: '0xroutehash',
+        }),
+      };
+    }
+  }
+  return { RelayClient };
+});
+
+vi.mock('@polymarket/builder-signing-sdk', () => {
+  class BuilderConfig {
+    constructor(_config: any) {}
+  }
+  return { BuilderConfig };
+});
+
+import { RelayerService } from '../../services/relayer-service.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_PK = '0x' + '1'.repeat(64);
+const TEST_SPENDER = '0x' + 'aa'.repeat(20);
+const TEST_RECIPIENT = '0x' + 'bb'.repeat(20);
+const TEST_CONDITION_ID = '0x' + 'cd'.repeat(32);
+
+function makeService(): RelayerService {
+  return new RelayerService({
+    builderCreds: { key: 'k', secret: 's', passphrase: 'p' },
+    privateKey: TEST_PK,
+    chainId: 137,
+    rpcUrl: 'http://localhost:0',
+  });
+}
+
+const ERC20_IFACE = new ethers.utils.Interface([
+  'function approve(address spender, uint256 amount) returns (bool)',
+  'function transfer(address to, uint256 amount) returns (bool)',
+]);
+
+const CTF_IFACE = new ethers.utils.Interface([
+  'function splitPosition(address collateralToken, bytes32 parentCollectionId, bytes32 conditionId, uint256[] partition, uint256 amount) external',
+  'function mergePositions(address collateralToken, bytes32 parentCollectionId, bytes32 conditionId, uint256[] partition, uint256 amount) external',
+  'function redeemPositions(address collateralToken, bytes32 parentCollectionId, bytes32 conditionId, uint256[] indexSets) external',
+]);
+
+beforeEach(() => {
+  capturedExecute = null;
+});
+
+// ---------------------------------------------------------------------------
+// approveUsdc
+// ---------------------------------------------------------------------------
+
+describe('RelayerService.approveUsdc — token routing', () => {
+  it('defaults to pUSD when no token is supplied (V2 trading collateral)', async () => {
+    const svc = makeService();
+    const r = await svc.approveUsdc(TEST_SPENDER, ethers.constants.MaxUint256);
+    expect(r.success).toBe(true);
+    expect(capturedExecute!.txs[0].to).toBe(POLYGON_CONTRACTS_V2.pUSD);
+
+    const decoded = ERC20_IFACE.decodeFunctionData('approve', capturedExecute!.txs[0].data);
+    expect(decoded.spender.toLowerCase()).toBe(TEST_SPENDER.toLowerCase());
+  });
+
+  it("routes to USDC.e when token === 'USDC.e' (off-exchange / Onramp approval)", async () => {
+    const svc = makeService();
+    const r = await svc.approveUsdc(TEST_SPENDER, BigNumber.from(123), 'USDC.e');
+    expect(r.success).toBe(true);
+    expect(capturedExecute!.txs[0].to).toBe(POLYGON_CONTRACTS_V2.usdcE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transferUsdc
+// ---------------------------------------------------------------------------
+
+describe('RelayerService.transferUsdc — token routing', () => {
+  it('defaults to pUSD (V2 strategy capital)', async () => {
+    const svc = makeService();
+    const r = await svc.transferUsdc(TEST_RECIPIENT, '50');
+    expect(r.success).toBe(true);
+    expect(capturedExecute!.txs[0].to).toBe(POLYGON_CONTRACTS_V2.pUSD);
+
+    const decoded = ERC20_IFACE.decodeFunctionData('transfer', capturedExecute!.txs[0].data);
+    expect(decoded.to.toLowerCase()).toBe(TEST_RECIPIENT.toLowerCase());
+    // 6 decimals: 50 → 50_000_000
+    expect(decoded.amount.toString()).toBe('50000000');
+  });
+
+  it("routes to USDC.e when token === 'USDC.e' (fund-out collect path)", async () => {
+    const svc = makeService();
+    const r = await svc.transferUsdc(TEST_RECIPIENT, '7', 'USDC.e');
+    expect(r.success).toBe(true);
+    expect(capturedExecute!.txs[0].to).toBe(POLYGON_CONTRACTS_V2.usdcE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// split / merge
+// ---------------------------------------------------------------------------
+
+describe('RelayerService.split — token routing', () => {
+  it('defaults to pUSD as the splitPosition collateral arg', async () => {
+    const svc = makeService();
+    const r = await svc.split(TEST_CONDITION_ID, '10');
+    expect(r.success).toBe(true);
+    expect(capturedExecute!.txs[0].to).toBe(CTF_CONTRACT);
+
+    const decoded = CTF_IFACE.decodeFunctionData('splitPosition', capturedExecute!.txs[0].data);
+    expect(decoded.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.pUSD.toLowerCase());
+  });
+
+  it("encodes USDC.e as collateral when token === 'USDC.e'", async () => {
+    const svc = makeService();
+    const r = await svc.split(TEST_CONDITION_ID, '10', false, 'USDC.e');
+    expect(r.success).toBe(true);
+
+    const decoded = CTF_IFACE.decodeFunctionData('splitPosition', capturedExecute!.txs[0].data);
+    expect(decoded.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.usdcE.toLowerCase());
+  });
+});
+
+describe('RelayerService.merge — token routing', () => {
+  it('defaults to pUSD as the mergePositions collateral arg', async () => {
+    const svc = makeService();
+    const r = await svc.merge(TEST_CONDITION_ID, '10');
+    expect(r.success).toBe(true);
+    expect(capturedExecute!.txs[0].to).toBe(CTF_CONTRACT);
+
+    const decoded = CTF_IFACE.decodeFunctionData('mergePositions', capturedExecute!.txs[0].data);
+    expect(decoded.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.pUSD.toLowerCase());
+  });
+
+  it("encodes USDC.e as collateral when token === 'USDC.e'", async () => {
+    const svc = makeService();
+    const r = await svc.merge(TEST_CONDITION_ID, '10', false, 'USDC.e');
+    expect(r.success).toBe(true);
+
+    const decoded = CTF_IFACE.decodeFunctionData('mergePositions', capturedExecute!.txs[0].data);
+    expect(decoded.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.usdcE.toLowerCase());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// redeem / redeemBatch
+// ---------------------------------------------------------------------------
+
+describe('RelayerService.redeem — token routing', () => {
+  it('defaults to pUSD on the standard CTF redeem path', async () => {
+    const svc = makeService();
+    const r = await svc.redeem(TEST_CONDITION_ID, 'YES');
+    expect(r.success).toBe(true);
+    expect(capturedExecute!.txs[0].to).toBe(CTF_CONTRACT);
+
+    const decoded = CTF_IFACE.decodeFunctionData(
+      'redeemPositions',
+      capturedExecute!.txs[0].data
+    );
+    expect(decoded.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.pUSD.toLowerCase());
+  });
+
+  it("encodes USDC.e on the standard CTF redeem path when token === 'USDC.e'", async () => {
+    const svc = makeService();
+    const r = await svc.redeem(TEST_CONDITION_ID, 'NO', false, 'USDC.e');
+    expect(r.success).toBe(true);
+
+    const decoded = CTF_IFACE.decodeFunctionData(
+      'redeemPositions',
+      capturedExecute!.txs[0].data
+    );
+    expect(decoded.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.usdcE.toLowerCase());
+  });
+
+  it('routes through NEG_RISK_ADAPTER for negRisk markets (token arg ignored)', async () => {
+    // NegRisk adapter doesn't take a collateral arg in redeemPositions.
+    // We just assert routing target.
+    const svc = makeService();
+    const r = await svc.redeem(TEST_CONDITION_ID, 'YES', true);
+    expect(r.success).toBe(true);
+    expect(capturedExecute!.txs[0].to).toBe(NEG_RISK_ADAPTER);
+  });
+});
+
+describe('RelayerService.redeemBatch — token routing', () => {
+  it('defaults each standard CTF entry to pUSD', async () => {
+    const svc = makeService();
+    const r = await svc.redeemBatch([
+      { conditionId: TEST_CONDITION_ID, outcome: 'YES' },
+      { conditionId: TEST_CONDITION_ID, outcome: 'NO' },
+    ]);
+    expect(r.success).toBe(true);
+    expect(capturedExecute!.txs).toHaveLength(2);
+
+    for (const tx of capturedExecute!.txs) {
+      expect(tx.to).toBe(CTF_CONTRACT);
+      const decoded = CTF_IFACE.decodeFunctionData('redeemPositions', tx.data);
+      expect(decoded.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.pUSD.toLowerCase());
+    }
+  });
+
+  it('honors per-entry token override (mixed pUSD + USDC.e batch)', async () => {
+    const svc = makeService();
+    const r = await svc.redeemBatch([
+      { conditionId: TEST_CONDITION_ID, outcome: 'YES' /* default pUSD */ },
+      { conditionId: TEST_CONDITION_ID, outcome: 'NO', token: 'USDC.e' },
+    ]);
+    expect(r.success).toBe(true);
+    expect(capturedExecute!.txs).toHaveLength(2);
+
+    const first = CTF_IFACE.decodeFunctionData(
+      'redeemPositions',
+      capturedExecute!.txs[0].data
+    );
+    const second = CTF_IFACE.decodeFunctionData(
+      'redeemPositions',
+      capturedExecute!.txs[1].data
+    );
+    expect(first.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.pUSD.toLowerCase());
+    expect(second.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.usdcE.toLowerCase());
+  });
+});

--- a/src/__tests__/unit/v2-relayer-wrap.test.ts
+++ b/src/__tests__/unit/v2-relayer-wrap.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Unit tests for V2 Relayer wrap / unwrap helpers.
+ *
+ * Stage C of the Polymarket V2 migration adds the USDC.e ↔ pUSD bridge
+ * helpers on `RelayerService`. The behavioural contract:
+ *
+ *   - `wrapUsdcToPUSD(amount)` calls the V2 Collateral Onramp's
+ *     `wrap(USDC.e, safeAddress, amount)` via `relayClient.execute()`.
+ *   - `unwrapPUSDtoUsdc(amount)` calls the V2 Collateral Offramp's
+ *     `unwrap(USDC.e, safeAddress, amount)` via `relayClient.execute()`.
+ *   - Both require non-zero `amountWei` — zero / negative reject without
+ *     touching the relay client.
+ *   - Failed relayer states (FAILED / INVALID) surface as
+ *     `success: false` with a descriptive `errorMessage`.
+ *
+ * We mock `@polymarket/builder-relayer-client` at module load so no network
+ * call ever happens; we only assert on the encoded transaction the service
+ * emits.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ethers } from 'ethers';
+import { POLYGON_CONTRACTS_V2 } from '../../constants/v2-contracts.js';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+// Capture the most recent `execute()` invocation so each test can assert
+// against it without holding a reference to the live mock.
+let capturedExecute: { txs: any[] } | null = null;
+let nextRelayState = 'STATE_CONFIRMED';
+let nextTxHash = '0xdeadbeef';
+
+vi.mock('@polymarket/builder-relayer-client', () => {
+  class RelayClient {
+    contractConfig = {
+      SafeContracts: {
+        SafeFactory: '0xaacFeEa03eb1561C4e67d661e40682Bd20E3541b',
+      },
+    };
+    constructor(_url: string, _chainId: number, _signer: any, _bc: any) {}
+    async getDeployed(_addr: string) {
+      return true;
+    }
+    async deploy() {
+      return { wait: async () => ({ state: 'STATE_CONFIRMED', transactionHash: '0x00' }) };
+    }
+    async execute(transactions: any[]) {
+      capturedExecute = { txs: transactions };
+      return {
+        wait: async () => ({
+          state: nextRelayState,
+          transactionHash: nextTxHash,
+        }),
+      };
+    }
+  }
+  return { RelayClient };
+});
+
+vi.mock('@polymarket/builder-signing-sdk', () => {
+  class BuilderConfig {
+    constructor(_config: any) {}
+  }
+  return { BuilderConfig };
+});
+
+// Import the service AFTER mocks are registered.
+import { RelayerService } from '../../services/relayer-service.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_PK = '0x' + '1'.repeat(64);
+
+function makeService(): RelayerService {
+  return new RelayerService({
+    builderCreds: { key: 'k', secret: 's', passphrase: 'p' },
+    privateKey: TEST_PK,
+    chainId: 137,
+    rpcUrl: 'http://localhost:0', // never reached because we don't make RPC calls
+  });
+}
+
+// Decode the `wrap` / `unwrap` calldata our service emitted.
+const RAMP_IFACE = new ethers.utils.Interface([
+  'function wrap(address asset, address to, uint256 amount) external',
+  'function unwrap(address asset, address to, uint256 amount) external',
+]);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RelayerService.wrapUsdcToPUSD', () => {
+  beforeEach(() => {
+    capturedExecute = null;
+    nextRelayState = 'STATE_CONFIRMED';
+    nextTxHash = '0xwraphash';
+  });
+
+  it('targets the V2 Collateral Onramp with wrap(USDC.e, safe, amount)', async () => {
+    const svc = makeService();
+    const safe = await svc.getSafeAddress();
+    const amount = 1_000_000n; // 1 USDC.e (6 decimals)
+
+    const r = await svc.wrapUsdcToPUSD(amount);
+
+    expect(r.success).toBe(true);
+    expect(r.txHash).toBe('0xwraphash');
+    expect(capturedExecute).not.toBeNull();
+    expect(capturedExecute!.txs).toHaveLength(1);
+
+    const tx = capturedExecute!.txs[0];
+    expect(tx.to).toBe(POLYGON_CONTRACTS_V2.collateralOnramp);
+    expect(tx.value).toBe('0');
+
+    const decoded = RAMP_IFACE.decodeFunctionData('wrap', tx.data);
+    expect(decoded.asset.toLowerCase()).toBe(
+      POLYGON_CONTRACTS_V2.usdcE.toLowerCase()
+    );
+    expect(decoded.to).toBe(safe);
+    expect(decoded.amount.toString()).toBe(amount.toString());
+  });
+
+  it('rejects zero amount without invoking the relay client', async () => {
+    const svc = makeService();
+    const r = await svc.wrapUsdcToPUSD(0n);
+    expect(r.success).toBe(false);
+    expect(r.errorMessage).toMatch(/amountWei must be > 0/);
+    expect(capturedExecute).toBeNull();
+  });
+
+  it('rejects negative amount without invoking the relay client', async () => {
+    const svc = makeService();
+    const r = await svc.wrapUsdcToPUSD(-1n);
+    expect(r.success).toBe(false);
+    expect(r.errorMessage).toMatch(/amountWei must be > 0/);
+    expect(capturedExecute).toBeNull();
+  });
+
+  it('reports failure when relayer state is FAILED', async () => {
+    nextRelayState = 'STATE_FAILED';
+    const svc = makeService();
+    const r = await svc.wrapUsdcToPUSD(123n);
+    expect(r.success).toBe(false);
+    expect(r.errorMessage).toMatch(/wrap.*STATE_FAILED/);
+  });
+
+  it('reports failure when relayer state is INVALID', async () => {
+    nextRelayState = 'STATE_INVALID';
+    const svc = makeService();
+    const r = await svc.wrapUsdcToPUSD(123n);
+    expect(r.success).toBe(false);
+    expect(r.errorMessage).toMatch(/wrap.*STATE_INVALID/);
+  });
+});
+
+describe('RelayerService.unwrapPUSDtoUsdc', () => {
+  beforeEach(() => {
+    capturedExecute = null;
+    nextRelayState = 'STATE_CONFIRMED';
+    nextTxHash = '0xunwraphash';
+  });
+
+  it('targets the V2 Collateral Offramp with unwrap(USDC.e, safe, amount)', async () => {
+    const svc = makeService();
+    const safe = await svc.getSafeAddress();
+    const amount = 5_000_000n; // 5 pUSD
+
+    const r = await svc.unwrapPUSDtoUsdc(amount);
+
+    expect(r.success).toBe(true);
+    expect(r.txHash).toBe('0xunwraphash');
+
+    const tx = capturedExecute!.txs[0];
+    expect(tx.to).toBe(POLYGON_CONTRACTS_V2.collateralOfframp);
+    expect(tx.value).toBe('0');
+
+    const decoded = RAMP_IFACE.decodeFunctionData('unwrap', tx.data);
+    expect(decoded.asset.toLowerCase()).toBe(
+      POLYGON_CONTRACTS_V2.usdcE.toLowerCase()
+    );
+    expect(decoded.to).toBe(safe);
+    expect(decoded.amount.toString()).toBe(amount.toString());
+  });
+
+  it('rejects zero amount without invoking the relay client', async () => {
+    const svc = makeService();
+    const r = await svc.unwrapPUSDtoUsdc(0n);
+    expect(r.success).toBe(false);
+    expect(r.errorMessage).toMatch(/amountWei must be > 0/);
+    expect(capturedExecute).toBeNull();
+  });
+
+  it('reports failure when relayer state is FAILED', async () => {
+    nextRelayState = 'STATE_FAILED';
+    const svc = makeService();
+    const r = await svc.unwrapPUSDtoUsdc(7n);
+    expect(r.success).toBe(false);
+    expect(r.errorMessage).toMatch(/unwrap.*STATE_FAILED/);
+  });
+
+  it('targets a different contract than wrap (Offramp ≠ Onramp)', () => {
+    expect(POLYGON_CONTRACTS_V2.collateralOnramp).not.toBe(
+      POLYGON_CONTRACTS_V2.collateralOfframp
+    );
+  });
+});

--- a/src/__tests__/unit/v2-trading-service-init.test.ts
+++ b/src/__tests__/unit/v2-trading-service-init.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for TradingService V2 initialization gating.
+ *
+ * Verifies the builder-code precedence (constructor config > env) and that
+ * order placement entry-points fail fast when neither is supplied.
+ *
+ * We do NOT call `initialize()` here — that would hit the live CLOB API to
+ * derive the L2 API key. Instead we exercise `ensureBuilderCode()` directly
+ * via the public order entry-points (which short-circuit before any network
+ * call when the builder code is missing).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TradingService } from '../../services/trading-service.js';
+import { RateLimiter } from '../../core/rate-limiter.js';
+import { createUnifiedCache } from '../../core/unified-cache.js';
+
+const ENV_KEY = 'POLY_BUILDER_CODE';
+const VALID_PK = '0x' + '1'.repeat(64);
+const VALID_BUILDER_CODE = '0x' + 'c'.repeat(64);
+
+function makeService(overrides: { builderCode?: string } = {}) {
+  return new TradingService(new RateLimiter(), createUnifiedCache(), {
+    privateKey: VALID_PK,
+    ...overrides,
+  });
+}
+
+describe('TradingService V2 — builder-code gating', () => {
+  let prev: string | undefined;
+
+  beforeEach(() => {
+    prev = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (prev === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = prev;
+    }
+  });
+
+  it('createLimitOrder throws when neither config nor env provides a builder code', async () => {
+    const svc = makeService();
+    // Use values that pass min-size/min-value validation so we reach the
+    // builder-code check rather than short-circuiting earlier.
+    await expect(
+      svc.createLimitOrder({
+        tokenId: '0xabc',
+        side: 'BUY',
+        price: 0.5,
+        size: 10,
+      })
+    ).rejects.toThrow(/POLY_BUILDER_CODE/);
+  });
+
+  it('createMarketOrder throws when builder code is missing', async () => {
+    const svc = makeService();
+    await expect(
+      svc.createMarketOrder({
+        tokenId: '0xabc',
+        side: 'BUY',
+        amount: 10,
+      })
+    ).rejects.toThrow(/POLY_BUILDER_CODE/);
+  });
+
+  it('createBatchOrders throws when builder code is missing', async () => {
+    const svc = makeService();
+    await expect(
+      svc.createBatchOrders([
+        { tokenId: '0xabc', side: 'BUY', price: 0.5, size: 10 },
+      ])
+    ).rejects.toThrow(/POLY_BUILDER_CODE/);
+  });
+
+  it('skips builder check when validation rejects the order before signing', async () => {
+    // Sub-minimum order size never reaches the builder-code gate; it returns
+    // a structured error result instead.
+    const svc = makeService();
+    const result = await svc.createLimitOrder({
+      tokenId: '0xabc',
+      side: 'BUY',
+      price: 0.5,
+      size: 1, // below the 5-share default minimum
+    });
+    expect(result.success).toBe(false);
+    expect(result.errorMsg).toMatch(/below Polymarket minimum/);
+  });
+
+  it('accepts builder code from constructor config (env not required)', () => {
+    const svc = makeService({ builderCode: VALID_BUILDER_CODE });
+    // ensureBuilderCode is private; reach it by calling the helper directly
+    // via a no-op order setup. Simpler: inspect that constructing the service
+    // and invoking the gate does not throw.
+    expect(() => (svc as any).ensureBuilderCode()).not.toThrow();
+  });
+
+  it('accepts builder code from POLY_BUILDER_CODE env when config omits it', () => {
+    process.env[ENV_KEY] = VALID_BUILDER_CODE;
+    const svc = makeService();
+    expect(() => (svc as any).ensureBuilderCode()).not.toThrow();
+  });
+
+  it('rejects malformed builder code from env even if config omits it', () => {
+    process.env[ENV_KEY] = '0xnope';
+    const svc = makeService();
+    expect(() => (svc as any).ensureBuilderCode()).toThrow(/bytes32/);
+  });
+});

--- a/src/__tests__/unit/v2-trading-service-init.test.ts
+++ b/src/__tests__/unit/v2-trading-service-init.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TradingService } from '../../services/trading-service.js';
 import { RateLimiter } from '../../core/rate-limiter.js';
 import { createUnifiedCache } from '../../core/unified-cache.js';
+import { PolymarketSDK } from '../../index.js';
 
 const ENV_KEY = 'POLY_BUILDER_CODE';
 const VALID_PK = '0x' + '1'.repeat(64);
@@ -108,5 +109,64 @@ describe('TradingService V2 — builder-code gating', () => {
     process.env[ENV_KEY] = '0xnope';
     const svc = makeService();
     expect(() => (svc as any).ensureBuilderCode()).toThrow(/bytes32/);
+  });
+});
+
+describe('PolymarketSDK V2 — builderCreds without builderCode is fail-fast', () => {
+  let prev: string | undefined;
+
+  beforeEach(() => {
+    prev = process.env.POLY_BUILDER_CODE;
+    delete process.env.POLY_BUILDER_CODE;
+  });
+
+  afterEach(() => {
+    if (prev === undefined) {
+      delete process.env.POLY_BUILDER_CODE;
+    } else {
+      process.env.POLY_BUILDER_CODE = prev;
+    }
+  });
+
+  it('throws clear migration error when builderCreds provided but builderCode missing', () => {
+    expect(
+      () =>
+        new PolymarketSDK({
+          privateKey: VALID_PK,
+          builderCreds: { key: 'k', secret: 's', passphrase: 'p' },
+        })
+    ).toThrow(/builderCreds.*builderCode|POLY_BUILDER_CODE/);
+  });
+
+  it('does not throw when both builderCreds and builderCode are provided', () => {
+    expect(
+      () =>
+        new PolymarketSDK({
+          privateKey: VALID_PK,
+          builderCreds: { key: 'k', secret: 's', passphrase: 'p' },
+          builderCode: VALID_BUILDER_CODE,
+        })
+    ).not.toThrow();
+  });
+
+  it('does not throw when builderCreds is omitted (relayer-less paths)', () => {
+    expect(
+      () =>
+        new PolymarketSDK({
+          privateKey: VALID_PK,
+          builderCode: VALID_BUILDER_CODE,
+        })
+    ).not.toThrow();
+  });
+
+  it('accepts builderCreds when POLY_BUILDER_CODE env supplies the code', () => {
+    process.env.POLY_BUILDER_CODE = VALID_BUILDER_CODE;
+    expect(
+      () =>
+        new PolymarketSDK({
+          privateKey: VALID_PK,
+          builderCreds: { key: 'k', secret: 's', passphrase: 'p' },
+        })
+    ).not.toThrow();
   });
 });

--- a/src/clients/ctf-client.ts
+++ b/src/clients/ctf-client.ts
@@ -24,33 +24,87 @@
  */
 
 import { ethers, Contract, Wallet, BigNumber } from 'ethers';
+import { POLYGON_CONTRACTS_V2 } from '../constants/v2-contracts.js';
 
 // ===== Contract Addresses (Polygon Mainnet) =====
 
+/** Conditional Tokens (CTF) ERC-1155. UNCHANGED across V1/V2. */
 export const CTF_CONTRACT = '0x4D97DCd97eC945f40cF65F87097ACe5EA0476045';
 
 /**
- * USDC.e (Bridged USDC) - The ONLY USDC accepted by Polymarket CTF
+ * USDC.e (Bridged USDC) - V1 collateral / off-exchange rail.
  *
  * ⚠️ WARNING: This is NOT native USDC (0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359)
  *
- * If your wallet has native USDC but CTF operations fail with "Insufficient USDC balance",
- * you need to swap your native USDC to USDC.e first using:
- * - SwapService.swap('USDC', 'USDC_E', amount)
- * - Or transfer USDC.e using SwapService.transferUsdcE()
+ * Post-2026-04-28 V2 cutover the on-exchange collateral is `pUSD`
+ * (`POLYGON_CONTRACTS_V2.pUSD`); USDC.e remains in use only for
+ * Onramp/Offramp wrap-unwrap and Safe-to-Safe transfers. Strategy code
+ * placing V2 orders MUST consume the pUSD address from
+ * `POLYGON_CONTRACTS_V2.pUSD` (or its alias `POLYMARKET_COLLATERAL_V2`
+ * exported below) — this constant only encodes the bridged-USDC rail.
  */
 export const USDC_CONTRACT = '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174';
 
 /** Native USDC on Polygon - NOT compatible with CTF */
 export const NATIVE_USDC_CONTRACT = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359';
 
-export const NEG_RISK_CTF_EXCHANGE = '0xC5d563A36AE78145C45a50134d48A1215220f80a';
+/**
+ * V1 NegRisk CTF Exchange address.
+ *
+ * @deprecated Replaced by `POLYGON_CONTRACTS_V2.negRiskExchange` (or its
+ * alias {@link NEG_RISK_CTF_EXCHANGE_V2}) at the 2026-04-28 V2 cutover.
+ * V1 CLOB rejects all V1-signed orders since cutover. This export is
+ * retained ONLY so legacy call sites compile; new code MUST consume the
+ * V2 address.
+ */
+export const NEG_RISK_CTF_EXCHANGE_V1_DEPRECATED = '0xC5d563A36AE78145C45a50134d48A1215220f80a';
+
+/**
+ * @deprecated Alias for {@link NEG_RISK_CTF_EXCHANGE_V1_DEPRECATED}.
+ * Will keep value-equal to the V1 address until the alias is removed in a
+ * follow-up major. New code should import {@link NEG_RISK_CTF_EXCHANGE_V2}.
+ */
+export const NEG_RISK_CTF_EXCHANGE = NEG_RISK_CTF_EXCHANGE_V1_DEPRECATED;
+
+/**
+ * V2 NegRisk CTF Exchange (canonical post-cutover).
+ *
+ * Re-exported here as a convenience alias alongside
+ * `POLYGON_CONTRACTS_V2.negRiskExchange`. Prefer importing from the V2
+ * constants module directly when consuming multiple V2 addresses.
+ */
+export const NEG_RISK_CTF_EXCHANGE_V2 = POLYGON_CONTRACTS_V2.negRiskExchange;
+
+/** NegRisk Adapter — wraps multi-outcome markets. UNCHANGED from V1. */
 export const NEG_RISK_ADAPTER = '0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296';
 
-/** CTF Exchange — Polymarket order matching contract for standard markets */
-export const CTF_EXCHANGE = '0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E';
+/**
+ * V1 CTF Exchange address — Polymarket order matching contract for standard
+ * markets, pre-V2 era.
+ *
+ * @deprecated Replaced by `POLYGON_CONTRACTS_V2.ctfExchange` (or its alias
+ * {@link CTF_EXCHANGE_V2}) at the 2026-04-28 V2 cutover. V1 CLOB rejects
+ * all V1-signed orders since cutover. This export is retained ONLY so
+ * legacy call sites compile; new code MUST consume the V2 address.
+ */
+export const CTF_EXCHANGE_V1_DEPRECATED = '0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E';
 
-// USDC.e uses 6 decimals
+/**
+ * @deprecated Alias for {@link CTF_EXCHANGE_V1_DEPRECATED}.
+ * Will keep value-equal to the V1 address until the alias is removed in a
+ * follow-up major. New code should import {@link CTF_EXCHANGE_V2}.
+ */
+export const CTF_EXCHANGE = CTF_EXCHANGE_V1_DEPRECATED;
+
+/**
+ * V2 CTF Exchange (canonical post-cutover).
+ *
+ * Re-exported here as a convenience alias alongside
+ * `POLYGON_CONTRACTS_V2.ctfExchange`.
+ */
+export const CTF_EXCHANGE_V2 = POLYGON_CONTRACTS_V2.ctfExchange;
+
+// USDC.e and pUSD both use 6 decimals (kept under USDC_DECIMALS for parity)
 export const USDC_DECIMALS = 6;
 
 // ===== ABIs =====

--- a/src/constants/builder-config.ts
+++ b/src/constants/builder-config.ts
@@ -1,0 +1,64 @@
+/**
+ * V2 Builder Code Helpers (SSOT)
+ * ----------------------------------------------------------------------------
+ * Polymarket CLOB V2 replaces the legacy HMAC-based builder attribution
+ * (`POLY_BUILDER_API_KEY` / `_SECRET` / `_PASSPHRASE`) with an on-chain
+ * `bytes32` field embedded inside the signed order struct (`Order.builder`).
+ *
+ * The V2 `ClobClient`'s `builderConfig: { builderCode: bytes32 }` option
+ * propagates this code into every order created/posted via the client. We
+ * source the code from `POLY_BUILDER_CODE` and validate the format before
+ * letting it reach the SDK so misconfiguration fails loudly at startup
+ * instead of silently as a malformed on-chain order.
+ *
+ * Migration plan: see `earning-engine/.claude/skills/guide-polymarket-v2-migration/`
+ *   - `plans/02-poly-sdk-migration.md` §6 — Builder Auth Split
+ *   - `plans/12-poly-sdk-pr-templates.md` §PR-B — env sourcing
+ *
+ * Note: HMAC creds (`POLY_BUILDER_API_KEY` etc.) are still required for the
+ * Relayer (gasless TX) path in `RelayerService`. They are NOT consumed by
+ * order signing in V2.
+ */
+
+/** Strict bytes32 format: `0x` followed by exactly 64 hex characters. */
+const BYTES32_REGEX = /^0x[0-9a-fA-F]{64}$/;
+
+/**
+ * Read and validate the V2 builder code from the environment.
+ *
+ * @throws if `POLY_BUILDER_CODE` is missing or not a valid bytes32 hex string.
+ *   The error message points to the SSOT plan so callers can self-diagnose.
+ */
+export function readBuilderCode(): string {
+  const code = process.env.POLY_BUILDER_CODE;
+  if (!code || !BYTES32_REGEX.test(code)) {
+    throw new Error(
+      'POLY_BUILDER_CODE env var must be set to a valid bytes32 ' +
+        '(0x followed by 64 hex chars). ' +
+        'See guide-polymarket-v2-migration/plans/12 §PR-B for sourcing.'
+    );
+  }
+  return code;
+}
+
+/**
+ * Read the V2 builder code if configured, returning `undefined` when absent.
+ *
+ * Useful for read-only paths (e.g. `MarketService` constructing a non-signing
+ * `ClobClient`) where a missing builder code is acceptable.
+ *
+ * Still throws if the env is set to a malformed value, so misconfiguration
+ * never silently degrades to "no builder attribution".
+ */
+export function readBuilderCodeOptional(): string | undefined {
+  const code = process.env.POLY_BUILDER_CODE;
+  if (code === undefined || code === '') return undefined;
+  if (!BYTES32_REGEX.test(code)) {
+    throw new Error(
+      'POLY_BUILDER_CODE env var is set but is not a valid bytes32 ' +
+        '(0x followed by 64 hex chars). ' +
+        'See guide-polymarket-v2-migration/plans/12 §PR-B for sourcing.'
+    );
+  }
+  return code;
+}

--- a/src/constants/v2-contracts.ts
+++ b/src/constants/v2-contracts.ts
@@ -60,15 +60,41 @@ export const POLYGON_CONTRACTS_V2 = {
   usdcE: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
 
   // -------------------------------------------------------------------------
-  // Onramp (TBD — Polygonscan ABI inspection pending)
+  // Onramp / Offramp (USDC.e ↔ pUSD)
   // -------------------------------------------------------------------------
 
   /**
-   * Collateral Onramp contract — handles USDC.e → pUSD wrapping for end users.
-   * Address pending: see `audits/01-poly-sdk-audit.md` P0-5 / `p0-fix-log` P0-05.
-   * To be filled in PR-C alongside `RelayerService.wrapUsdcToPUSD()` impl.
+   * Collateral Onramp — handles USDC.e → pUSD wrapping (1:1, no fee).
+   *
+   * Sourced from Polymarket V2 docs (`docs.polymarket.com/resources/contracts`)
+   * and verified on-chain: bytecode exposes `wrap(address,address,uint256)`
+   * (selector `0x62355638`) and `COLLATERAL_TOKEN()` returns the pUSD proxy.
+   *
+   * ABI (verified via on-chain selector probe + docs):
+   *   `wrap(address asset, address to, uint256 amount)` — pulls `amount` of
+   *   `asset` (must be USDC.e) from caller and mints the same amount of pUSD
+   *   to `to`. Caller MUST `approve(onramp, amount)` on USDC.e first.
+   *
+   * Used by `RelayerService.wrapUsdcToPUSD()` (Safe → Onramp.wrap, gasless).
    */
-  // collateralOnramp: '0x...',
+  collateralOnramp: '0x93070a847efEf7F70739046A929D47a521F5B8ee',
+
+  /**
+   * Collateral Offramp — handles pUSD → USDC.e unwrapping (1:1, no fee).
+   *
+   * Distinct from the Onramp on V2 (V1 had no equivalent — USDC.e was the
+   * collateral directly). Verified on-chain: bytecode exposes
+   * `unwrap(address,address,uint256)` (selector `0x8cc7104f`) and
+   * `COLLATERAL_TOKEN()` returns the same pUSD proxy as the Onramp.
+   *
+   * ABI:
+   *   `unwrap(address asset, address to, uint256 amount)` — burns `amount` of
+   *   pUSD from caller and releases the same amount of `asset` (must be
+   *   USDC.e) to `to`. Caller MUST `approve(offramp, amount)` on pUSD first.
+   *
+   * Used by `RelayerService.unwrapPUSDtoUsdc()` (Safe → Offramp.unwrap).
+   */
+  collateralOfframp: '0x2957922Eb93258b93368531d39fAcCA3B4dC5854',
 } as const;
 
 /**

--- a/src/constants/v2-contracts.ts
+++ b/src/constants/v2-contracts.ts
@@ -1,0 +1,128 @@
+/**
+ * Polymarket CLOB V2 Contract Constants (SSOT)
+ * ----------------------------------------------------------------------------
+ * V2 cutover: 2026-04-28 (UTC). All legacy V1 CTF Exchange / NegRisk Exchange
+ * addresses below are kept ONLY as `@deprecated` references for migration
+ * traceability — production callers MUST consume the V2 addresses.
+ *
+ * Verified sources:
+ *   - V2 SDK source (`@polymarket/clob-client-v2@1.0.3`):
+ *     `dist/index.js` `getContractConfig()` table.
+ *   - Polygonscan ABI / proxy admin inspection (collateral + onramp pending).
+ *
+ * Migration plan: see `earning-engine/.claude/skills/guide-polymarket-v2-migration/`
+ *   - `plans/02-poly-sdk-migration.md`        — overall workstream
+ *   - `plans/12-poly-sdk-pr-templates.md` §PR-A — this PR's scope
+ *   - `audits/01-poly-sdk-audit.md`            — provenance for each address
+ */
+
+/**
+ * V2 contract addresses on Polygon mainnet (chain 137).
+ * All addresses are checksummed exactly as returned by `getContractConfig(137)`
+ * in `@polymarket/clob-client-v2`.
+ */
+export const POLYGON_CONTRACTS_V2 = {
+  // -------------------------------------------------------------------------
+  // Core exchanges (CHANGED in V2)
+  // -------------------------------------------------------------------------
+
+  /** V2 CTF Exchange — replaces V1 `0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E`. */
+  ctfExchange: '0xE111180000d2663C0091e4f400237545B87B996B',
+
+  /** V2 NegRisk CTF Exchange — replaces V1 `0xC5d563A36AE78145C45a50134d48A1215220f80a`. */
+  negRiskExchange: '0xe2222d279d744050d28e00520010520000310F59',
+
+  // -------------------------------------------------------------------------
+  // Conditional Tokens (UNCHANGED from V1)
+  // -------------------------------------------------------------------------
+
+  /** NegRisk Adapter — wraps multi-outcome markets. UNCHANGED from V1. */
+  negRiskAdapter: '0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296',
+
+  /** ConditionalTokens (CTF) ERC-1155 token contract. UNCHANGED from V1. */
+  ctfContract: '0x4D97DCd97eC945f40cF65F87097ACe5EA0476045',
+
+  // -------------------------------------------------------------------------
+  // Collateral
+  // -------------------------------------------------------------------------
+
+  /**
+   * pUSD — V2 collateral token. 1:1 backed by USDC.e and supports unwrap
+   * back to USDC.e via the pUSD contract itself.
+   */
+  pUSD: '0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB',
+
+  /**
+   * USDC.e (bridged USDC) — V1 collateral, retained for fund-flow paths
+   * (Relayer transfers, swap rails, withdrawal collect). Orders post-V2
+   * MUST settle in pUSD; USDC.e here is purely for off-exchange flows.
+   */
+  usdcE: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+
+  // -------------------------------------------------------------------------
+  // Onramp (TBD — Polygonscan ABI inspection pending)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Collateral Onramp contract — handles USDC.e → pUSD wrapping for end users.
+   * Address pending: see `audits/01-poly-sdk-audit.md` P0-5 / `p0-fix-log` P0-05.
+   * To be filled in PR-C alongside `RelayerService.wrapUsdcToPUSD()` impl.
+   */
+  // collateralOnramp: '0x...',
+} as const;
+
+/**
+ * Legacy V1 addresses (for reference / grep traceability).
+ *
+ * @deprecated Do not consume from production paths. V1 CLOB rejects all
+ * V1-signed orders since 2026-04-28. These are kept here so that searches
+ * for old addresses still surface a single SSOT result.
+ */
+export const POLYGON_CONTRACTS_V1_LEGACY = {
+  /** @deprecated Replaced by `POLYGON_CONTRACTS_V2.ctfExchange`. */
+  ctfExchange: '0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E',
+  /** @deprecated Replaced by `POLYGON_CONTRACTS_V2.negRiskExchange`. */
+  negRiskExchange: '0xC5d563A36AE78145C45a50134d48A1215220f80a',
+} as const;
+
+/**
+ * EIP-712 domain version constants.
+ *
+ * The Polymarket protocol exposes TWO independent EIP-712 domains:
+ *
+ *   1. CTF Exchange domain — used to sign on-chain order structs.
+ *      Bumped from "1" → "2" at the V2 cutover. Order signing MUST use
+ *      `domainVersionV2`.
+ *
+ *   2. ClobAuthDomain — used to sign API auth challenges (HMAC bootstrap
+ *      and L1 header generation). UNCHANGED at V2: still `"1"`.
+ *
+ * The V2 SDK encapsulates these internally (it picks `"2"` automatically
+ * when building V2-shaped orders). These constants exist so that any future
+ * raw-signing path (e.g. unit tests, fixture generators, calldata decoders)
+ * shares the same SSOT.
+ */
+export const EIP_712 = {
+  /** Domain `name` for CTF Exchange (UNCHANGED across V1/V2). */
+  domainName: 'Polymarket CTF Exchange',
+
+  /** @deprecated V1 CTF Exchange domain version — kept for hash parity tests only. */
+  domainVersionV1: '1',
+
+  /** V2 CTF Exchange domain version — production order signing MUST use this. */
+  domainVersionV2: '2',
+
+  /** ClobAuthDomain version — UNCHANGED at V2 (API auth uses `"1"`). */
+  clobAuthDomainVersion: '1',
+} as const;
+
+/** Polygon mainnet chain id. */
+export const POLYGON_CHAIN_ID = 137 as const;
+
+/** Polygon Amoy testnet chain id (kept for parity with `POLYGON_AMOY` in trading-service). */
+export const POLYGON_AMOY_CHAIN_ID = 80002 as const;
+
+// Type helpers ---------------------------------------------------------------
+
+export type PolygonContractsV2 = typeof POLYGON_CONTRACTS_V2;
+export type Eip712Constants = typeof EIP_712;

--- a/src/core/order-status.ts
+++ b/src/core/order-status.ts
@@ -5,7 +5,7 @@
  * Provides helper functions for status validation and state transitions.
  */
 
-import type { OpenOrder } from '@polymarket/clob-client';
+import type { OpenOrder } from '@polymarket/clob-client-v2';
 import { OrderStatus } from './types.js';
 import { createModuleLogger } from './logger.js';
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -267,8 +267,13 @@ export interface PolySDKOptions {
   mempoolWssUrl?: string;
 
   /**
-   * Builder API credentials for fee sharing and gasless order execution.
-   * Enables Builder mode with Polymarket's Builder Relayer.
+   * Builder API credentials (HMAC three-tuple) for the **Relayer / gasless TX**
+   * envelope path (`@polymarket/builder-signing-sdk`). Still required after the
+   * 2026-04-28 V2 cutover for Safe deployment / approvals / fund movement.
+   *
+   * NOTE: V2 order signing no longer uses HMAC creds — order attribution is
+   * now carried by the bytes32 `builderCode` (see `builderCode` below). Pass
+   * both fields when running a full Builder flow.
    */
   builderCreds?: {
     key: string;
@@ -277,8 +282,18 @@ export interface PolySDKOptions {
   };
 
   /**
+   * V2 builder code (bytes32, e.g. `0x...64hex`). Embedded in every signed
+   * order's `Order.builder` field for on-chain attribution. Falls back to the
+   * `POLY_BUILDER_CODE` env var when omitted.
+   *
+   * Required for any path that places orders post-2026-04-28 cutover.
+   */
+  builderCode?: string;
+
+  /**
    * Gnosis Safe address for Builder mode.
-   * When provided with builderCreds, orders use Safe as maker/funder.
+   * When provided with `builderCode`, orders are signed by the EOA owner but
+   * use the Safe as maker/funder (`SignatureTypeV2.POLY_GNOSIS_SAFE`).
    * Derive via RelayerService.getSafeAddress() or deploy via RelayerService.deploySafe().
    */
   safeAddress?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -435,16 +435,24 @@ export type {
 // TradingService provides all trading functionality with proper type exports
 
 // CTF (Conditional Token Framework)
-// NOTE: USDC_CONTRACT is USDC.e (bridged), required for Polymarket CTF
-// NATIVE_USDC_CONTRACT is native USDC, NOT compatible with CTF
+// NOTE: USDC_CONTRACT is USDC.e (bridged) — V1 collateral / off-exchange rail.
+//   V2 trading collateral is pUSD (POLYGON_CONTRACTS_V2.pUSD).
+// NATIVE_USDC_CONTRACT is native USDC, NOT compatible with CTF.
+// CTF_EXCHANGE / NEG_RISK_CTF_EXCHANGE are V1 addresses (kept @deprecated
+// for back-compat); new code must consume CTF_EXCHANGE_V2 /
+// NEG_RISK_CTF_EXCHANGE_V2 (or POLYGON_CONTRACTS_V2 directly).
 export {
   CTFClient,
   CTF_CONTRACT,
-  USDC_CONTRACT,           // USDC.e (0x2791...) - Required for CTF
+  USDC_CONTRACT,           // USDC.e (0x2791...) - V1 collateral / off-exchange rail
   NATIVE_USDC_CONTRACT,    // Native USDC (0x3c49...) - NOT for CTF
-  NEG_RISK_CTF_EXCHANGE,
+  NEG_RISK_CTF_EXCHANGE,                  // @deprecated alias for NEG_RISK_CTF_EXCHANGE_V1_DEPRECATED
+  NEG_RISK_CTF_EXCHANGE_V1_DEPRECATED,    // V1 (pre-cutover)
+  NEG_RISK_CTF_EXCHANGE_V2,               // V2 canonical
   NEG_RISK_ADAPTER,
-  CTF_EXCHANGE,
+  CTF_EXCHANGE,                           // @deprecated alias for CTF_EXCHANGE_V1_DEPRECATED
+  CTF_EXCHANGE_V1_DEPRECATED,             // V1 (pre-cutover)
+  CTF_EXCHANGE_V2,                        // V2 canonical
   USDC_DECIMALS,
   calculateConditionId,
   parseUsdc,
@@ -462,6 +470,21 @@ export type {
   TokenIds,
 } from './clients/ctf-client.js';
 export { RevertReason } from './clients/ctf-client.js';
+
+// V2 contract SSOT — re-export so consumers can import the canonical V2
+// addresses (`POLYGON_CONTRACTS_V2.{ctfExchange,negRiskExchange,pUSD,...}`)
+// without reaching into the constants/ module path.
+export {
+  POLYGON_CONTRACTS_V2,
+  POLYGON_CONTRACTS_V1_LEGACY,
+  EIP_712,
+  POLYGON_CHAIN_ID,
+  POLYGON_AMOY_CHAIN_ID,
+} from './constants/v2-contracts.js';
+export type {
+  PolygonContractsV2,
+  Eip712Constants,
+} from './constants/v2-contracts.js';
 
 // Bridge (Cross-chain Deposits)
 export {
@@ -624,6 +647,37 @@ export class PolymarketSDK {
   private _initialized = false;
 
   constructor(config: PolymarketSDKConfig = {}) {
+    // -----------------------------------------------------------------------
+    // V2 migration guard: fail-fast if caller still relies on V1-style HMAC
+    // creds for order signing.
+    //
+    // Background: pre-V2, `builderCreds` (HMAC three-tuple) flowed into the
+    // trading path and produced a HMAC-signed builder header. Post-2026-04-28
+    // V2 cutover, order attribution moved to a bytes32 `builderCode` embedded
+    // directly in the order struct, and HMAC creds are only used for the
+    // Relayer / gasless TX path. TypeScript's structural typing still accepts
+    // an old `{ builderCreds }` config object on `PolymarketSDKConfig` (the
+    // field stays on `PolySDKOptions` because Relayer needs it), so without
+    // an explicit guard the SDK silently drops the old auth and the first
+    // signed order surfaces the V1→V2 drift only at runtime.
+    //
+    // We require: when `builderCreds` is supplied, `builderCode` (or the
+    // `POLY_BUILDER_CODE` env) MUST also be supplied. This catches the
+    // ambiguous "still on the V1 mental model" call sites without breaking
+    // pure-Relayer setups (which would normally not pass `builderCreds`
+    // through `PolymarketSDK`'s constructor anyway).
+    // -----------------------------------------------------------------------
+    if (config.builderCreds && !config.builderCode && !process.env.POLY_BUILDER_CODE) {
+      throw new Error(
+        'PolymarketSDK: `builderCreds` (V1 HMAC three-tuple) is no longer used ' +
+        'for order signing after the 2026-04-28 V2 cutover. Order attribution ' +
+        'is now carried by the bytes32 `builderCode` (Order.builder field). ' +
+        'Set the POLY_BUILDER_CODE env var (32-byte hex) or pass ' +
+        '`builderCode` in `PolymarketSDKConfig` alongside `builderCreds`. ' +
+        'See guide-polymarket-v2-migration for the full migration path.'
+      );
+    }
+
     // Initialize infrastructure
     this.rateLimiter = new RateLimiter();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -640,7 +640,10 @@ export class PolymarketSDK {
       privateKey,
       chainId: config.chainId,
       credentials: config.creds,
-      builderCreds: config.builderCreds,
+      // V2: order signing uses `builderCode` (bytes32). HMAC `builderCreds`
+      // are still on the SDK options (for Relayer), but no longer flow into
+      // the trading path.
+      builderCode: config.builderCode,
       safeAddress: config.safeAddress,
       dataApi: this.dataApi,
     });

--- a/src/services/authorization-service.ts
+++ b/src/services/authorization-service.ts
@@ -1,25 +1,33 @@
 /**
  * Authorization Service
  *
- * Manages ERC20 and ERC1155 approvals required for trading on Polymarket.
+ * Manages ERC20 and ERC1155 approvals required for trading on Polymarket V2.
  *
- * Required approvals for trading:
- * - ERC20 (USDC): Approve USDC spending for CTF Exchange, Neg Risk Exchange, etc.
- * - ERC1155 (Conditional Tokens): Approve operators for conditional token transfers
+ * V2 collateral model (post-2026-04-28 cutover):
+ *   - Trading collateral is pUSD (not USDC.e). pUSD is approved to the V2
+ *     CTF Exchange + V2 NegRisk Exchange + NegRisk Adapter.
+ *   - USDC.e remains relevant ONLY as the "off-exchange" rail:
+ *       USDC.e --(approve Onramp)--> wrap() --> pUSD
+ *     The USDC.e approval target is therefore the Collateral Onramp, NOT any
+ *     V2 Exchange. This service emits separate approval rows for the two
+ *     tokens.
+ *   - ERC1155 (Conditional Tokens) operators are the V2 Exchanges + the
+ *     NegRisk Adapter, all unchanged in spirit but pointing at V2 addresses.
  *
- * @see https://docs.polymarket.com/
+ * V1 approvals on V1 Exchanges are NOT revoked by this service — they are
+ * harmless on the V2 rail (V1 Exchange contracts no longer accept orders).
+ * Callers wanting to revoke can do so manually; default `approveAll()` only
+ * sets the V2 approval matrix.
+ *
+ * @see https://docs.polymarket.com/v2-migration
+ * @see ../constants/v2-contracts.ts (V2 contract SSOT)
  */
 
 import { ethers } from 'ethers';
-import {
-  CTF_CONTRACT,
-  NEG_RISK_CTF_EXCHANGE,
-  NEG_RISK_ADAPTER,
-  USDC_CONTRACT,
-} from '../clients/ctf-client.js';
+import { CTF_CONTRACT } from '../clients/ctf-client.js';
+import { POLYGON_CONTRACTS_V2 } from '../constants/v2-contracts.js';
 
-// Contract addresses
-const CTF_EXCHANGE = '0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E';
+// Conditional Tokens ERC1155 (UNCHANGED across V1/V2).
 const CONDITIONAL_TOKENS = CTF_CONTRACT;
 
 // ABIs
@@ -40,10 +48,21 @@ export interface AllowanceInfo {
   address: string;
   approved: boolean;
   allowance?: string;
+  /** ERC20 only: which token's allowance this row reports (`pUSD` vs `USDC.e`). */
+  token?: 'pUSD' | 'USDC.e';
 }
 
 export interface AllowancesResult {
   wallet: string;
+  /** Wallet's pUSD balance (V2 trading collateral). */
+  pusdBalance: string;
+  /** Wallet's USDC.e balance (off-exchange rail). */
+  usdcEBalance: string;
+  /**
+   * @deprecated Use `pusdBalance` for V2 trading-readiness. Kept as an alias of
+   * `pusdBalance` so older readers don't break; the field name predates the
+   * V2 cutover where USDC.e was the trading collateral.
+   */
   usdcBalance: string;
   erc20Allowances: AllowanceInfo[];
   erc1155Approvals: AllowanceInfo[];
@@ -56,6 +75,8 @@ export interface ApprovalTxResult {
   txHash?: string;
   success: boolean;
   error?: string;
+  /** ERC20 only: which token's allowance was set in this row. */
+  token?: 'pUSD' | 'USDC.e';
 }
 
 export interface ApprovalsResult {
@@ -70,19 +91,45 @@ export interface AuthorizationServiceConfig {
   provider?: ethers.providers.Provider;
 }
 
-// Contracts that need ERC20 approval
-const ERC20_SPENDERS = [
-  { name: 'CTF Exchange', address: CTF_EXCHANGE },
-  { name: 'Neg Risk CTF Exchange', address: NEG_RISK_CTF_EXCHANGE },
-  { name: 'Neg Risk Adapter', address: NEG_RISK_ADAPTER },
-  { name: 'Conditional Tokens', address: CONDITIONAL_TOKENS },
+/**
+ * V2 ERC20 spender matrix.
+ *
+ * Two distinct token rails:
+ *   - `pUSD` rows: trading collateral; approved to V2 Exchanges + Adapter so
+ *     the matchOrders flow can pull pUSD from the maker/taker.
+ *   - `USDC.e` row: NOT trading collateral on V2; the approval is to the
+ *     Collateral Onramp so `wrap(USDC.e → pUSD)` can pull USDC.e from the
+ *     wallet and mint pUSD to the same address.
+ *
+ * The optional `token` field disambiguates which ERC20 contract this row
+ * targets. Older callers that ignore the field default to pUSD-correct
+ * behaviour because all four V2 trading rows are pUSD.
+ */
+interface V2Erc20Spender {
+  name: string;
+  address: string;
+  token: 'pUSD' | 'USDC.e';
+}
+
+const ERC20_SPENDERS_V2: readonly V2Erc20Spender[] = [
+  { name: 'V2 CTF Exchange',         address: POLYGON_CONTRACTS_V2.ctfExchange,      token: 'pUSD' },
+  { name: 'V2 NegRisk CTF Exchange', address: POLYGON_CONTRACTS_V2.negRiskExchange,  token: 'pUSD' },
+  { name: 'NegRisk Adapter',         address: POLYGON_CONTRACTS_V2.negRiskAdapter,   token: 'pUSD' },
+  { name: 'Onramp (USDC.e wrap)',    address: POLYGON_CONTRACTS_V2.collateralOnramp, token: 'USDC.e' },
 ];
 
-// Operators that need ERC1155 approval
-const ERC1155_OPERATORS = [
-  { name: 'CTF Exchange', address: CTF_EXCHANGE },
-  { name: 'Neg Risk CTF Exchange', address: NEG_RISK_CTF_EXCHANGE },
-  { name: 'Neg Risk Adapter', address: NEG_RISK_ADAPTER },
+/**
+ * V2 ERC1155 operator list — operators that may transfer the wallet's
+ * Conditional Token balances during order matching / NegRisk redemption.
+ *
+ * The NegRisk Adapter is retained as a separate operator: the V2 NegRisk
+ * Exchange relies on the Adapter for split/merge during multi-outcome
+ * resolution and the Adapter must be able to move the wallet's CTF tokens.
+ */
+const ERC1155_OPERATORS_V2 = [
+  { name: 'V2 CTF Exchange',         address: POLYGON_CONTRACTS_V2.ctfExchange },
+  { name: 'V2 NegRisk CTF Exchange', address: POLYGON_CONTRACTS_V2.negRiskExchange },
+  { name: 'NegRisk Adapter',         address: POLYGON_CONTRACTS_V2.negRiskAdapter },
 ];
 
 /**
@@ -121,24 +168,45 @@ export class AuthorizationService {
   }
 
   /**
-   * Check all ERC20 and ERC1155 allowances required for trading
+   * Resolve the ERC20 token contract address for a V2 spender row.
+   *
+   * pUSD rows trade through the V2 Exchanges; USDC.e rows feed the Onramp.
+   * Centralised so future V2 token additions only edit one place.
+   */
+  private erc20ContractForToken(token: 'pUSD' | 'USDC.e'): string {
+    return token === 'pUSD'
+      ? POLYGON_CONTRACTS_V2.pUSD
+      : POLYGON_CONTRACTS_V2.usdcE;
+  }
+
+  /**
+   * Check all V2 ERC20 and ERC1155 allowances required for trading.
+   *
+   * Reads pUSD balance + per-spender allowances on both pUSD and USDC.e, and
+   * ERC1155 approvals on Conditional Tokens for the V2 operator set.
    *
    * @returns Status of all allowances and whether trading is ready
    */
   async checkAllowances(): Promise<AllowancesResult> {
     const walletAddress = this.signer.address;
 
-    const usdc = new ethers.Contract(USDC_CONTRACT, ERC20_ABI, this.provider);
+    const pusd = new ethers.Contract(POLYGON_CONTRACTS_V2.pUSD, ERC20_ABI, this.provider);
+    const usdcE = new ethers.Contract(POLYGON_CONTRACTS_V2.usdcE, ERC20_ABI, this.provider);
     const conditionalTokens = new ethers.Contract(CONDITIONAL_TOKENS, ERC1155_ABI, this.provider);
 
-    // Check USDC balance
-    const balance = await usdc.balanceOf(walletAddress);
-    const balanceFormatted = ethers.utils.formatUnits(balance, 6);
+    // Balances
+    const [pusdBal, usdcEBal] = await Promise.all([
+      pusd.balanceOf(walletAddress),
+      usdcE.balanceOf(walletAddress),
+    ]);
+    const pusdBalance = ethers.utils.formatUnits(pusdBal, 6);
+    const usdcEBalance = ethers.utils.formatUnits(usdcEBal, 6);
 
-    // Check ERC20 allowances
+    // Check ERC20 allowances per V2 spender row (token-specific)
     const erc20Allowances: AllowanceInfo[] = [];
-    for (const spender of ERC20_SPENDERS) {
-      const allowance = await usdc.allowance(walletAddress, spender.address);
+    for (const spender of ERC20_SPENDERS_V2) {
+      const tokenContract = spender.token === 'pUSD' ? pusd : usdcE;
+      const allowance = await tokenContract.allowance(walletAddress, spender.address);
       const allowanceNum = parseFloat(ethers.utils.formatUnits(allowance, 6));
       const isUnlimited = allowanceNum > 1e12;
 
@@ -147,12 +215,13 @@ export class AuthorizationService {
         address: spender.address,
         approved: isUnlimited,
         allowance: isUnlimited ? 'unlimited' : allowanceNum.toFixed(2),
+        token: spender.token,
       });
     }
 
     // Check ERC1155 approvals
     const erc1155Approvals: AllowanceInfo[] = [];
-    for (const operator of ERC1155_OPERATORS) {
+    for (const operator of ERC1155_OPERATORS_V2) {
       const isApproved = await conditionalTokens.isApprovedForAll(walletAddress, operator.address);
 
       erc1155Approvals.push({
@@ -166,7 +235,7 @@ export class AuthorizationService {
     const issues: string[] = [];
     for (const a of erc20Allowances) {
       if (!a.approved) {
-        issues.push(`ERC20: ${a.contract} needs USDC approval`);
+        issues.push(`ERC20 ${a.token ?? 'pUSD'}: ${a.contract} needs approval`);
       }
     }
     for (const a of erc1155Approvals) {
@@ -179,7 +248,10 @@ export class AuthorizationService {
 
     return {
       wallet: walletAddress,
-      usdcBalance: balanceFormatted,
+      pusdBalance,
+      usdcEBalance,
+      // Backward-compat: alias of `pusdBalance` (V2 trading collateral).
+      usdcBalance: pusdBalance,
       erc20Allowances,
       erc1155Approvals,
       tradingReady,
@@ -188,49 +260,61 @@ export class AuthorizationService {
   }
 
   /**
-   * Set up all required approvals for trading
+   * Set up all required V2 approvals for trading.
+   *
+   * - 3 pUSD approvals (to V2 CTF Exchange / V2 NegRisk Exchange / NegRisk Adapter)
+   * - 1 USDC.e approval (to Collateral Onramp, for `wrap()`)
+   * - 3 ERC1155 approvals (V2 Exchanges + Adapter as Conditional Tokens operators)
    *
    * @returns Results of all approval transactions
    */
   async approveAll(): Promise<ApprovalsResult> {
     const walletAddress = this.signer.address;
 
-    const usdc = new ethers.Contract(USDC_CONTRACT, ERC20_ABI, this.signer);
+    const tokenContracts = {
+      pUSD: new ethers.Contract(POLYGON_CONTRACTS_V2.pUSD, ERC20_ABI, this.signer),
+      'USDC.e': new ethers.Contract(POLYGON_CONTRACTS_V2.usdcE, ERC20_ABI, this.signer),
+    } as const;
     const conditionalTokens = new ethers.Contract(CONDITIONAL_TOKENS, ERC1155_ABI, this.signer);
 
     // Get gas price with buffer
     const gasPrice = await this.provider.getGasPrice();
     const adjustedGasPrice = gasPrice.mul(150).div(100); // 1.5x
 
-    // Process ERC20 approvals
+    // Process ERC20 approvals (token-aware)
     const erc20Results: ApprovalTxResult[] = [];
-    for (const spender of ERC20_SPENDERS) {
+    for (const spender of ERC20_SPENDERS_V2) {
+      const tokenContract = tokenContracts[spender.token];
+
       // Check current allowance
-      const allowance = await usdc.allowance(walletAddress, spender.address);
+      const allowance = await tokenContract.allowance(walletAddress, spender.address);
       const allowanceNum = parseFloat(ethers.utils.formatUnits(allowance, 6));
 
       if (allowanceNum > 1e12) {
         // Already approved
         erc20Results.push({
           contract: spender.name,
+          token: spender.token,
           success: true,
         });
         continue;
       }
 
       try {
-        const tx = await usdc.approve(spender.address, ethers.constants.MaxUint256, {
+        const tx = await tokenContract.approve(spender.address, ethers.constants.MaxUint256, {
           gasPrice: adjustedGasPrice,
         });
         await tx.wait();
         erc20Results.push({
           contract: spender.name,
+          token: spender.token,
           txHash: tx.hash,
           success: true,
         });
       } catch (err) {
         erc20Results.push({
           contract: spender.name,
+          token: spender.token,
           success: false,
           error: err instanceof Error ? err.message : 'Unknown error',
         });
@@ -239,7 +323,7 @@ export class AuthorizationService {
 
     // Process ERC1155 approvals
     const erc1155Results: ApprovalTxResult[] = [];
-    for (const operator of ERC1155_OPERATORS) {
+    for (const operator of ERC1155_OPERATORS_V2) {
       // Check current approval
       const isApproved = await conditionalTokens.isApprovedForAll(walletAddress, operator.address);
 
@@ -291,31 +375,39 @@ export class AuthorizationService {
   }
 
   /**
-   * Approve USDC spending for a specific contract
+   * Approve a single ERC20 spender.
+   *
+   * Defaults to pUSD (V2 trading collateral). Pass `token: 'USDC.e'` for
+   * Onramp / off-exchange paths.
    *
    * @param spenderAddress - The contract address to approve
    * @param amount - The amount to approve (default: unlimited)
+   * @param token - Which ERC20 to approve from (default: pUSD)
    */
   async approveUsdc(
     spenderAddress: string,
-    amount: ethers.BigNumber = ethers.constants.MaxUint256
+    amount: ethers.BigNumber = ethers.constants.MaxUint256,
+    token: 'pUSD' | 'USDC.e' = 'pUSD'
   ): Promise<ApprovalTxResult> {
-    const usdc = new ethers.Contract(USDC_CONTRACT, ERC20_ABI, this.signer);
+    const tokenAddress = this.erc20ContractForToken(token);
+    const erc20 = new ethers.Contract(tokenAddress, ERC20_ABI, this.signer);
     const gasPrice = await this.provider.getGasPrice();
 
     try {
-      const tx = await usdc.approve(spenderAddress, amount, {
+      const tx = await erc20.approve(spenderAddress, amount, {
         gasPrice: gasPrice.mul(150).div(100),
       });
       await tx.wait();
       return {
         contract: spenderAddress,
+        token,
         txHash: tx.hash,
         success: true,
       };
     } catch (err) {
       return {
         contract: spenderAddress,
+        token,
         success: false,
         error: err instanceof Error ? err.message : 'Unknown error',
       };

--- a/src/services/market-service.ts
+++ b/src/services/market-service.ts
@@ -15,8 +15,9 @@ import {
   Chain,
   PriceHistoryInterval,
   type OrderBookSummary,
-} from '@polymarket/clob-client';
+} from '@polymarket/clob-client-v2';
 import { Wallet } from 'ethers';
+import { readBuilderCodeOptional } from '../constants/builder-config.js';
 import { DataApiClient, Trade } from '../clients/data-api.js';
 import { GammaApiClient, GammaMarket } from '../clients/gamma-api.js';
 import type { UnifiedCache } from '../core/unified-cache.js';
@@ -207,15 +208,32 @@ export class MarketService {
 
   private async ensureInitialized(): Promise<ClobClient> {
     if (!this.initialized || !this.clobClient) {
-      const chainId = (this.config?.chainId || POLYGON_MAINNET) as Chain;
+      const chain = (this.config?.chainId || POLYGON_MAINNET) as Chain;
+
+      // V2 SDK uses an options-bag constructor; `chain` replaces `chainId`.
+      // MarketService is read-only — no order signing — so `builderConfig`
+      // is optional. We still propagate `POLY_BUILDER_CODE` if set so a
+      // single SDK can be passed through to signing paths without redoing
+      // setup, but never *require* it here.
+      const builderCode = readBuilderCodeOptional();
+      const builderConfig = builderCode ? { builderCode } : undefined;
 
       if (this.config?.privateKey) {
         // Authenticated client
         const wallet = new Wallet(this.config.privateKey);
-        this.clobClient = new ClobClient(CLOB_HOST, chainId, wallet);
+        this.clobClient = new ClobClient({
+          host: CLOB_HOST,
+          chain,
+          signer: wallet,
+          builderConfig,
+        });
       } else {
         // Read-only client (no auth needed for market data)
-        this.clobClient = new ClobClient(CLOB_HOST, chainId);
+        this.clobClient = new ClobClient({
+          host: CLOB_HOST,
+          chain,
+          builderConfig,
+        });
       }
       this.initialized = true;
     }

--- a/src/services/order-manager.ts
+++ b/src/services/order-manager.ts
@@ -213,8 +213,17 @@ export interface OrderManagerConfig {
   pollingInterval?: number;
   /** RPC URL for Polygon provider (for settlement tracking) */
   polygonRpcUrl?: string;
-  /** Builder API credentials (for gasless operations and fee sharing) */
+  /**
+   * Builder API HMAC credentials. Retained on the OrderManager surface for
+   * compatibility / Relayer-side flows; **not** consumed by V2 order signing
+   * (use `builderCode` instead).
+   */
   builderCreds?: { key: string; secret: string; passphrase: string };
+  /**
+   * V2 builder code (bytes32). Embedded in every signed order's `builder`
+   * field on V2. Falls back to `POLY_BUILDER_CODE` env var when omitted.
+   */
+  builderCode?: string;
   /** Gnosis Safe address — required for Builder mode so orders use Safe as maker */
   safeAddress?: string;
 }
@@ -693,7 +702,7 @@ export class OrderManager extends EventEmitter {
   private polygonProvider: ethers.providers.Provider | null = null;
 
   // ========== Configuration ==========
-  private config: Required<Omit<OrderManagerConfig, 'builderCreds' | 'safeAddress'>> & Pick<OrderManagerConfig, 'builderCreds' | 'safeAddress'>;
+  private config: Required<Omit<OrderManagerConfig, 'builderCreds' | 'builderCode' | 'safeAddress'>> & Pick<OrderManagerConfig, 'builderCreds' | 'builderCode' | 'safeAddress'>;
   private initialized = false;
 
   // ========== Monitoring State ==========
@@ -725,13 +734,16 @@ export class OrderManager extends EventEmitter {
     const cache = config.cache || createUnifiedCache();
 
     // Initialize TradingService (always needed)
+    // V2: order signing reads `builderCode` (bytes32) — HMAC `builderCreds`
+    // are no longer threaded into TradingService, but remain on the
+    // OrderManagerConfig for upstream Relayer flows.
     this.tradingService = new TradingService(
       rateLimiter,
       cache,
       {
         privateKey: config.privateKey,
         chainId: this.config.chainId,
-        builderCreds: config.builderCreds,
+        builderCode: config.builderCode,
         safeAddress: config.safeAddress,
       }
     );

--- a/src/services/relayer-service.ts
+++ b/src/services/relayer-service.ts
@@ -28,6 +28,7 @@ import {
   USDC_CONTRACT,
   USDC_DECIMALS,
 } from '../clients/ctf-client.js';
+import { POLYGON_CONTRACTS_V2 } from '../constants/v2-contracts.js';
 
 // ============================================================================
 // Types
@@ -94,6 +95,20 @@ const ERC20_ABI = [
 
 const ERC1155_ABI = [
   'function setApprovalForAll(address operator, bool approved) external',
+];
+
+/**
+ * Polymarket V2 Collateral Onramp / Offramp ABI.
+ *
+ * Both endpoints share the same `(address asset, address to, uint256 amount)`
+ * shape. Verified on-chain via selector probe: `wrap = 0x62355638`,
+ * `unwrap = 0x8cc7104f`. See `src/constants/v2-contracts.ts` for source
+ * provenance and the `guide-polymarket-v2-migration` skill for migration
+ * context.
+ */
+const COLLATERAL_RAMP_ABI = [
+  'function wrap(address asset, address to, uint256 amount) external',
+  'function unwrap(address asset, address to, uint256 amount) external',
 ];
 
 // ============================================================================
@@ -258,6 +273,136 @@ export class RelayerService {
         return {
           success: false,
           errorMessage: `USDC approval failed: ${tx?.state || 'No transaction'}`,
+        };
+      }
+
+      return {
+        success: true,
+        txHash: tx.transactionHash,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        errorMessage: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  /**
+   * Wrap USDC.e → pUSD via the V2 Collateral Onramp (gasless, 1:1, no fee).
+   *
+   * V2 trade settlement uses pUSD as collateral. Each Safe must wrap its
+   * USDC.e holdings to pUSD before placing its first V2 order. This is
+   * relay-encoded so it costs the Safe no gas.
+   *
+   * Pre-conditions (NOT enforced here — caller must ensure):
+   *   1. Safe has approved the Onramp (`POLYGON_CONTRACTS_V2.collateralOnramp`)
+   *      to spend USDC.e on its behalf — see `AuthorizationService.approveAll()`.
+   *   2. Safe has at least `amountWei` USDC.e balance.
+   *
+   * The minted pUSD is delivered to the Safe itself (the Safe is `_to`).
+   *
+   * @param amountWei - amount in USDC.e base units (6 decimals). MUST be
+   *   non-zero; the contract will revert on zero amount.
+   * @returns RelayerResult with transaction status
+   *
+   * @example
+   * ```typescript
+   * // Wrap 100 USDC.e → 100 pUSD on the caller's Safe
+   * const amount = ethers.utils.parseUnits("100", 6);
+   * const r = await relayer.wrapUsdcToPUSD(amount.toBigInt());
+   * ```
+   */
+  async wrapUsdcToPUSD(amountWei: bigint): Promise<RelayerResult> {
+    if (amountWei <= 0n) {
+      return {
+        success: false,
+        errorMessage: 'wrapUsdcToPUSD: amountWei must be > 0',
+      };
+    }
+
+    const safeAddress = await this.getSafeAddress();
+    const rampInterface = new ethers.utils.Interface(COLLATERAL_RAMP_ABI);
+    const data = rampInterface.encodeFunctionData('wrap', [
+      POLYGON_CONTRACTS_V2.usdcE,
+      safeAddress,
+      BigNumber.from(amountWei),
+    ]);
+
+    try {
+      const response = await this.relayClient.execute([{
+        to: POLYGON_CONTRACTS_V2.collateralOnramp,
+        value: '0',
+        data,
+      }]);
+
+      const tx = await response.wait();
+
+      if (!tx || tx.state === RelayerState.FAILED || tx.state === RelayerState.INVALID) {
+        return {
+          success: false,
+          errorMessage: `wrap (USDC.e → pUSD) failed: ${tx?.state || 'No transaction'}`,
+        };
+      }
+
+      return {
+        success: true,
+        txHash: tx.transactionHash,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        errorMessage: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  /**
+   * Unwrap pUSD → USDC.e via the V2 Collateral Offramp (gasless, 1:1, no fee).
+   *
+   * Reverses {@link wrapUsdcToPUSD}. Useful for `ee wallet collect` flows
+   * that need to drain a strategy Safe back to USDC.e (the canonical
+   * non-trading rail) before transferring to main.
+   *
+   * Pre-conditions (NOT enforced here — caller must ensure):
+   *   1. Safe has approved the Offramp (`POLYGON_CONTRACTS_V2.collateralOfframp`)
+   *      to spend pUSD on its behalf — currently NOT in the default V2
+   *      approval matrix; callers needing unwrap must explicitly approve
+   *      pUSD → Offramp first via the V1-style ERC20 contract call.
+   *   2. Safe has at least `amountWei` pUSD balance.
+   *
+   * @param amountWei - amount in pUSD base units (6 decimals).
+   * @returns RelayerResult with transaction status.
+   */
+  async unwrapPUSDtoUsdc(amountWei: bigint): Promise<RelayerResult> {
+    if (amountWei <= 0n) {
+      return {
+        success: false,
+        errorMessage: 'unwrapPUSDtoUsdc: amountWei must be > 0',
+      };
+    }
+
+    const safeAddress = await this.getSafeAddress();
+    const rampInterface = new ethers.utils.Interface(COLLATERAL_RAMP_ABI);
+    const data = rampInterface.encodeFunctionData('unwrap', [
+      POLYGON_CONTRACTS_V2.usdcE,
+      safeAddress,
+      BigNumber.from(amountWei),
+    ]);
+
+    try {
+      const response = await this.relayClient.execute([{
+        to: POLYGON_CONTRACTS_V2.collateralOfframp,
+        value: '0',
+        data,
+      }]);
+
+      const tx = await response.wait();
+
+      if (!tx || tx.state === RelayerState.FAILED || tx.state === RelayerState.INVALID) {
+        return {
+          success: false,
+          errorMessage: `unwrap (pUSD → USDC.e) failed: ${tx?.state || 'No transaction'}`,
         };
       }
 

--- a/src/services/relayer-service.ts
+++ b/src/services/relayer-service.ts
@@ -25,7 +25,6 @@ import { ethers, Wallet, BigNumber } from 'ethers';
 import {
   CTF_CONTRACT,
   NEG_RISK_ADAPTER,
-  USDC_CONTRACT,
   USDC_DECIMALS,
 } from '../clients/ctf-client.js';
 import { POLYGON_CONTRACTS_V2 } from '../constants/v2-contracts.js';
@@ -72,6 +71,33 @@ export interface RelayerResult {
 
 export interface SafeDeployResult extends RelayerResult {
   safeAddress: string;
+}
+
+// ============================================================================
+// V2 collateral routing
+// ============================================================================
+
+/**
+ * Collateral token identifier used to route Relayer ops to the correct
+ * ERC-20 contract. V2 trade settlement collateral is `pUSD`; `USDC.e` is
+ * retained for off-exchange flows (Safe-to-Safe transfers, fund-out collect,
+ * legacy migrations).
+ *
+ * Defaults across this service are `'pUSD'` to match the post-V2 trading
+ * collateral. Pass `'USDC.e'` explicitly only for fund-flow paths that
+ * intentionally bypass pUSD wrapping (e.g. `ee wallet collect` draining a
+ * Safe back to USDC.e before transfer to main).
+ */
+export type CollateralToken = 'pUSD' | 'USDC.e';
+
+/**
+ * Resolve a {@link CollateralToken} identifier to its on-chain ERC-20
+ * contract address.
+ */
+function resolveCollateralAddress(token: CollateralToken): string {
+  return token === 'pUSD'
+    ? POLYGON_CONTRACTS_V2.pUSD
+    : POLYGON_CONTRACTS_V2.usdcE;
 }
 
 // ============================================================================
@@ -251,18 +277,28 @@ export class RelayerService {
   }
 
   /**
-   * Approve USDC.e for CTF operations
+   * Approve a collateral token for CTF / Onramp / Offramp operations.
    *
-   * @param spender - Spender address (typically CTF_CONTRACT)
+   * V2 default is `pUSD` (the trading collateral). Pass `'USDC.e'` for
+   * off-exchange flows (e.g. approving the Onramp prior to wrap, or legacy
+   * V1-style direct approvals).
+   *
+   * @param spender - Spender address (CTF_CONTRACT, Onramp/Offramp, etc.)
    * @param amount - Amount to approve (use MaxUint256 for unlimited)
+   * @param token - Collateral token to approve. Defaults to `'pUSD'`.
    */
-  async approveUsdc(spender: string, amount: BigNumber): Promise<RelayerResult> {
+  async approveUsdc(
+    spender: string,
+    amount: BigNumber,
+    token: CollateralToken = 'pUSD'
+  ): Promise<RelayerResult> {
     const usdcInterface = new ethers.utils.Interface(ERC20_ABI);
     const data = usdcInterface.encodeFunctionData('approve', [spender, amount]);
+    const collateralAddress = resolveCollateralAddress(token);
 
     try {
       const response = await this.relayClient.execute([{
-        to: USDC_CONTRACT,
+        to: collateralAddress,
         value: '0',
         data,
       }]);
@@ -419,32 +455,47 @@ export class RelayerService {
   }
 
   /**
-   * Transfer USDC.e to another address via Relayer (gasless)
+   * Transfer collateral (default `pUSD`) to another address via Relayer
+   * (gasless).
    *
-   * Enables Safe-to-EOA or Safe-to-Safe USDC transfers without gas fees.
-   * Useful for fund distribution/collection from main wallet to strategy wallets.
+   * Enables Safe-to-EOA or Safe-to-Safe collateral transfers without gas
+   * fees. Useful for fund distribution / collection between main wallet and
+   * strategy wallets.
+   *
+   * Defaults to `'pUSD'` so post-V2 strategy flows (which keep working
+   * capital in pUSD) work out of the box. Pass `'USDC.e'` for fund-out
+   * paths that drain unwrapped USDC.e back to main.
    *
    * @param recipient - Recipient address (can be EOA or another Safe)
-   * @param amount - USDC amount in human-readable format (e.g., "100" for 100 USDC)
+   * @param amount   - Amount in human-readable format (e.g., "100" for 100
+   *                   pUSD or 100 USDC.e — both are 6-decimal tokens).
+   * @param token    - Collateral token to transfer. Defaults to `'pUSD'`.
    * @returns RelayerResult with transaction status
    *
    * @example
    * ```typescript
-   * // Withdraw from Safe to main wallet
-   * const result = await relayer.transferUsdc("0x0f5988a267303f46b50912f176450491df10476f", "300");
-   * if (result.success) {
-   *   console.log(`Transfer tx: ${result.txHash}`);
-   * }
+   * // Default V2: transfer pUSD between strategy Safes
+   * await relayer.transferUsdc(otherSafe, "300");
+   *
+   * // Fund-out: drain unwrapped USDC.e back to main wallet
+   * await relayer.transferUsdc(mainEoa, "300", 'USDC.e');
    * ```
    */
-  async transferUsdc(recipient: string, amount: string): Promise<RelayerResult> {
+  async transferUsdc(
+    recipient: string,
+    amount: string,
+    token: CollateralToken = 'pUSD'
+  ): Promise<RelayerResult> {
+    // pUSD and USDC.e both use 6 decimals; reusing USDC_DECIMALS keeps
+    // parity with the V1 path while routing the transfer to the right token.
     const amountWei = ethers.utils.parseUnits(amount, USDC_DECIMALS);
     const usdcInterface = new ethers.utils.Interface(ERC20_ABI);
     const data = usdcInterface.encodeFunctionData('transfer', [recipient, amountWei]);
+    const collateralAddress = resolveCollateralAddress(token);
 
     try {
       const response = await this.relayClient.execute([{
-        to: USDC_CONTRACT,
+        to: collateralAddress,
         value: '0',
         data,
       }]);
@@ -510,26 +561,38 @@ export class RelayerService {
   }
 
   /**
-   * Split USDC into YES + NO tokens (gasless)
+   * Split collateral into YES + NO tokens (gasless).
+   *
+   * V2 markets settle in pUSD, so the default `token` is `'pUSD'`. Legacy
+   * markets (or fixtures still on USDC.e collateral) can pass `'USDC.e'`.
    *
    * @param conditionId - Market condition ID
-   * @param amount - USDC amount in human-readable format (e.g., "100" for 100 USDC)
+   * @param amount      - Collateral amount in human-readable format (e.g.,
+   *                      "100" for 100 pUSD).
+   * @param isNegRisk   - True for NegRisk markets (routes via adapter).
+   * @param token       - Collateral token. Defaults to `'pUSD'`.
    * @returns RelayerResult with transaction status
    *
    * @example
    * ```typescript
-   * const result = await relayer.split(conditionId, "100");
+   * const result = await relayer.split(conditionId, "100"); // V2 default = pUSD
    * if (result.success) {
    *   console.log(`Split tx: ${result.txHash}`);
    * }
    * ```
    */
-  async split(conditionId: string, amount: string, isNegRisk = false): Promise<RelayerResult> {
+  async split(
+    conditionId: string,
+    amount: string,
+    isNegRisk = false,
+    token: CollateralToken = 'pUSD'
+  ): Promise<RelayerResult> {
     const amountWei = ethers.utils.parseUnits(amount, USDC_DECIMALS);
     const ctfInterface = new ethers.utils.Interface(CTF_ABI);
+    const collateralAddress = resolveCollateralAddress(token);
 
     const data = ctfInterface.encodeFunctionData('splitPosition', [
-      USDC_CONTRACT,
+      collateralAddress,
       ethers.constants.HashZero, // parentCollectionId
       conditionId,
       [1, 2], // partition [YES, NO]
@@ -567,18 +630,30 @@ export class RelayerService {
   }
 
   /**
-   * Merge YES + NO tokens back to USDC (gasless)
+   * Merge YES + NO tokens back to collateral (gasless).
+   *
+   * Defaults to pUSD (V2). Pass `'USDC.e'` for legacy positions that still
+   * settle in USDC.e.
    *
    * @param conditionId - Market condition ID
-   * @param amount - Number of token pairs to merge (e.g., "100" for 100 YES + 100 NO)
+   * @param amount      - Number of token pairs to merge (e.g., "100" for
+   *                      100 YES + 100 NO).
+   * @param isNegRisk   - True for NegRisk markets (routes via adapter).
+   * @param token       - Collateral token to receive. Defaults to `'pUSD'`.
    * @returns RelayerResult with transaction status
    */
-  async merge(conditionId: string, amount: string, isNegRisk = false): Promise<RelayerResult> {
+  async merge(
+    conditionId: string,
+    amount: string,
+    isNegRisk = false,
+    token: CollateralToken = 'pUSD'
+  ): Promise<RelayerResult> {
     const amountWei = ethers.utils.parseUnits(amount, USDC_DECIMALS);
     const ctfInterface = new ethers.utils.Interface(CTF_ABI);
+    const collateralAddress = resolveCollateralAddress(token);
 
     const data = ctfInterface.encodeFunctionData('mergePositions', [
-      USDC_CONTRACT,
+      collateralAddress,
       ethers.constants.HashZero,
       conditionId,
       [1, 2],
@@ -616,13 +691,25 @@ export class RelayerService {
   }
 
   /**
-   * Redeem winning tokens to USDC (gasless)
+   * Redeem winning tokens back to collateral (gasless).
+   *
+   * Defaults to pUSD (V2). NegRisk adapter does not take a collateral
+   * argument (it knows the market's collateral on-chain), so the `token`
+   * argument is only consumed by the standard CTF path.
    *
    * @param conditionId - Market condition ID
-   * @param outcome - Winning outcome ('YES' or 'NO')
+   * @param outcome     - Winning outcome ('YES' or 'NO')
+   * @param isNegRisk   - True for NegRisk markets (routes via adapter).
+   * @param token       - Collateral token (standard CTF only). Defaults to
+   *                      `'pUSD'`.
    * @returns RelayerResult with transaction status
    */
-  async redeem(conditionId: string, outcome: 'YES' | 'NO', isNegRisk = false): Promise<RelayerResult> {
+  async redeem(
+    conditionId: string,
+    outcome: 'YES' | 'NO',
+    isNegRisk = false,
+    token: CollateralToken = 'pUSD'
+  ): Promise<RelayerResult> {
     let data: string;
     let to: string;
 
@@ -641,8 +728,9 @@ export class RelayerService {
       // Standard CTF: redeemPositions(collateral, parentCollectionId, conditionId, indexSets)
       const indexSets = outcome === 'YES' ? [1] : [2];
       const ctfInterface = new ethers.utils.Interface(CTF_ABI);
+      const collateralAddress = resolveCollateralAddress(token);
       data = ctfInterface.encodeFunctionData('redeemPositions', [
-        USDC_CONTRACT,
+        collateralAddress,
         ethers.constants.HashZero,
         conditionId,
         indexSets,
@@ -726,24 +814,41 @@ export class RelayerService {
   }
 
   /**
-   * Batch redeem multiple winning positions in a single relayer call (gasless)
+   * Batch redeem multiple winning positions in a single relayer call
+   * (gasless).
    *
-   * @param redeems - Array of { conditionId, outcome } to redeem
+   * Each entry can specify its own collateral `token` (defaults to `'pUSD'`)
+   * to support mixed batches across V2 (pUSD) and legacy (USDC.e) markets.
+   *
+   * @param redeems - Array of { conditionId, outcome, isNegRisk?, token? }
+   *                  to redeem.
    * @returns RelayerResult with transaction status
    */
-  async redeemBatch(redeems: Array<{ conditionId: string; outcome: 'YES' | 'NO'; isNegRisk?: boolean }>): Promise<RelayerResult> {
+  async redeemBatch(
+    redeems: Array<{
+      conditionId: string;
+      outcome: 'YES' | 'NO';
+      isNegRisk?: boolean;
+      token?: CollateralToken;
+    }>
+  ): Promise<RelayerResult> {
     if (redeems.length === 0) {
       return { success: true };
     }
 
     // Single redeem — use simple path
     if (redeems.length === 1) {
-      return this.redeem(redeems[0].conditionId, redeems[0].outcome, redeems[0].isNegRisk);
+      return this.redeem(
+        redeems[0].conditionId,
+        redeems[0].outcome,
+        redeems[0].isNegRisk,
+        redeems[0].token ?? 'pUSD'
+      );
     }
 
     const ctfInterface = new ethers.utils.Interface(CTF_ABI);
     const negRiskInterface = new ethers.utils.Interface(NEG_RISK_ADAPTER_ABI);
-    const transactions = redeems.map(({ conditionId, outcome, isNegRisk }) => {
+    const transactions = redeems.map(({ conditionId, outcome, isNegRisk, token }) => {
       let data: string;
       let to: string;
       if (isNegRisk) {
@@ -755,8 +860,9 @@ export class RelayerService {
         to = NEG_RISK_ADAPTER;
       } else {
         const indexSets = outcome === 'YES' ? [1] : [2];
+        const collateralAddress = resolveCollateralAddress(token ?? 'pUSD');
         data = ctfInterface.encodeFunctionData('redeemPositions', [
-          USDC_CONTRACT,
+          collateralAddress,
           ethers.constants.HashZero,
           conditionId,
           indexSets,

--- a/src/services/trading-service.ts
+++ b/src/services/trading-service.ts
@@ -1,7 +1,7 @@
 /**
  * TradingService
  *
- * Trading service using official @polymarket/clob-client.
+ * Trading service using official @polymarket/clob-client-v2 (CLOB V2).
  *
  * Provides:
  * - Order creation (limit, market)
@@ -15,6 +15,16 @@
  * Orders below these limits are validated and rejected before sending to API.
  *
  * Note: Market data methods have been moved to MarketService.
+ *
+ * V2 migration notes:
+ * - Constructor switched from positional args to options-bag (`{ host, chain, ... }`).
+ * - `builderConfig` content changed from HMAC three-tuple to `{ builderCode }`.
+ * - Order struct now embeds `timestamp(ms)` / `metadata(bytes32)` / `builder(bytes32)`
+ *   in place of `nonce` / `feeRateBps` / `taker` — the SDK populates these
+ *   fields internally; callers only forward `expiration` and `builderCode`
+ *   (the latter via `builderConfig`).
+ * - HMAC creds (`@polymarket/builder-signing-sdk`) are still used by RelayerService
+ *   for gasless TX envelopes; only the *order signing* path swaps to builderCode.
  */
 
 import {
@@ -22,16 +32,14 @@ import {
   Side as ClobSide,
   OrderType as ClobOrderType,
   Chain,
+  SignatureTypeV2,
   type OpenOrder,
   type Trade as ClobTrade,
   type TickSize,
-} from '@polymarket/clob-client';
-
-// SignatureType from @polymarket/order-utils (transitive dep, not directly importable)
-// Values: EOA = 0, POLY_PROXY = 1, POLY_GNOSIS_SAFE = 2
-const SIGNATURE_TYPE_POLY_GNOSIS_SAFE = 2;
+} from '@polymarket/clob-client-v2';
 
 import { Wallet } from 'ethers';
+import { readBuilderCode, readBuilderCodeOptional } from '../constants/builder-config.js';
 import { RateLimiter, ApiType } from '../core/rate-limiter.js';
 import type { UnifiedCache } from '../core/unified-cache.js';
 import { CACHE_TTL } from '../core/unified-cache.js';
@@ -100,13 +108,24 @@ export interface TradingServiceConfig {
   chainId?: number;
   /** Pre-generated API credentials (optional) */
   credentials?: ApiCredentials;
-  /** Builder API credentials (optional) - enables Builder mode with fee sharing and rewards */
-  builderCreds?: {
-    key: string;
-    secret: string;
-    passphrase: string;
-  };
-  /** Gnosis Safe address — required for Builder mode so orders use Safe as maker/funder */
+  /**
+   * V2 builder code (bytes32). When provided, every order signed by this
+   * service is attributed to this code on-chain. Falls back to the
+   * `POLY_BUILDER_CODE` env var when omitted.
+   *
+   * Required for any order placement path; throws at `initialize()` if neither
+   * config nor env supplies a valid code.
+   *
+   * Note: replaces the V1 `builderCreds` HMAC three-tuple. HMAC creds are
+   * still consumed by `RelayerService` for gasless TX envelopes; they are
+   * NOT used by V2 order signing.
+   */
+  builderCode?: string;
+  /**
+   * Gnosis Safe address — required for Builder mode so orders use Safe as
+   * maker/funder. Setting this together with a builder code switches the
+   * signature type to `POLY_GNOSIS_SAFE` (matches V1 behaviour).
+   */
   safeAddress?: string;
   /** Data API client — required for clearPosition() to fetch size internally */
   dataApi?: DataApiClient;
@@ -355,8 +374,33 @@ export class TradingService {
   async initialize(): Promise<void> {
     if (this.initialized) return;
 
-    // Create CLOB client with L1 auth (wallet)
-    this.clobClient = new ClobClient(CLOB_HOST, this.chainId, this.wallet);
+    // Resolve builder code: explicit config > env. Allow undefined here so
+    // read-only auth flows (deriveApiKey/createApiKey) can run without it,
+    // but enforce presence before any order is placed (see ensureBuilderCode).
+    // Note: readBuilderCodeOptional throws on a malformed env value, so a
+    // typo fails loudly even if no code is required for the current call.
+    const resolvedBuilderCode =
+      this.config.builderCode !== undefined
+        ? this.config.builderCode
+        : readBuilderCodeOptional();
+
+    // Builder mode: orders use Safe as maker, signed by EOA owner. In V2 the
+    // trigger is `safeAddress` set together with a builder code — HMAC creds
+    // are no longer involved in this branch.
+    const isBuilderMode = !!resolvedBuilderCode && !!this.config.safeAddress;
+    const builderConfig = resolvedBuilderCode
+      ? { builderCode: resolvedBuilderCode }
+      : undefined;
+
+    // Create CLOB client with L1 auth (wallet) for API-key derivation. We
+    // attach the builderConfig up front so any subsequent re-init keeps
+    // identical attribution.
+    this.clobClient = new ClobClient({
+      host: CLOB_HOST,
+      chain: this.chainId,
+      signer: this.wallet,
+      builderConfig,
+    });
 
     // Get or create API credentials
     // We use derive-first strategy (opposite of official createOrDeriveApiKey)
@@ -370,40 +414,39 @@ export class TradingService {
       };
     }
 
-    // Construct BuilderConfig if builderCreds are provided
-    let builderConfig: any = undefined;
-    if (this.config.builderCreds) {
-      const { BuilderConfig } = await import('@polymarket/builder-signing-sdk');
-      builderConfig = new BuilderConfig({
-        localBuilderCreds: {
-          key: this.config.builderCreds.key,
-          secret: this.config.builderCreds.secret,
-          passphrase: this.config.builderCreds.passphrase,
-        },
-      });
-    }
-
-    // Builder mode: orders use Safe as maker, signed by EOA owner
-    const isBuilderMode = !!this.config.builderCreds && !!this.config.safeAddress;
-
-    // Re-initialize with L2 auth (credentials) and optional BuilderConfig
-    this.clobClient = new ClobClient(
-      CLOB_HOST,
-      this.chainId,
-      this.wallet,
-      {
+    // Re-initialize with L2 auth (credentials) and (optional) builder config.
+    // V2 ClobClient takes a single options object; `chain` replaces V1
+    // `chainId`, `signatureType`/`funderAddress`/`builderConfig` are nested.
+    this.clobClient = new ClobClient({
+      host: CLOB_HOST,
+      chain: this.chainId,
+      signer: this.wallet,
+      creds: {
         key: this.credentials.key,
         secret: this.credentials.secret,
         passphrase: this.credentials.passphrase,
       },
-      isBuilderMode ? SIGNATURE_TYPE_POLY_GNOSIS_SAFE : undefined, // signatureType
-      isBuilderMode ? this.config.safeAddress : undefined,         // funderAddress (Safe holds the tokens)
-      undefined, // geoBlockToken
-      undefined, // useServerTime
-      builderConfig, // BuilderConfig (arg 9)
-    );
+      signatureType: isBuilderMode ? SignatureTypeV2.POLY_GNOSIS_SAFE : undefined,
+      funderAddress: isBuilderMode ? this.config.safeAddress : undefined,
+      builderConfig,
+    });
 
     this.initialized = true;
+  }
+
+  /**
+   * Validate that a V2 builder code is available before any order placement
+   * path. Pulled into a helper so each order entry-point fails fast with the
+   * same diagnostic.
+   */
+  private ensureBuilderCode(): void {
+    if (
+      this.config.builderCode === undefined &&
+      readBuilderCodeOptional() === undefined
+    ) {
+      // readBuilderCode() raises with the canonical error message + plan link.
+      readBuilderCode();
+    }
   }
 
   /**
@@ -500,6 +543,8 @@ export class TradingService {
       };
     }
 
+    // V2 attribution: every signed order MUST carry a builder code.
+    this.ensureBuilderCode();
     const client = await this.ensureInitialized();
 
     return this.rateLimiter.execute(ApiType.CLOB_API, async () => {
@@ -511,6 +556,11 @@ export class TradingService {
 
         const orderType = params.orderType === 'GTD' ? ClobOrderType.GTD : ClobOrderType.GTC;
 
+        // V2 UserOrder shape: only `expiration` (unix seconds) is forwarded
+        // explicitly; the SDK populates `timestamp` (ms), `metadata` (zero
+        // bytes32), and `builder` (from `builderConfig.builderCode`)
+        // internally during order signing. `nonce` / `feeRateBps` / `taker`
+        // are removed by V2.
         const result = await client.createAndPostOrder(
           {
             tokenID: params.tokenId,
@@ -567,6 +617,7 @@ export class TradingService {
       };
     }
 
+    this.ensureBuilderCode();
     const client = await this.ensureInitialized();
 
     return this.rateLimiter.execute(ApiType.CLOB_API, async () => {
@@ -578,6 +629,9 @@ export class TradingService {
 
         const orderType = params.orderType === 'FAK' ? ClobOrderType.FAK : ClobOrderType.FOK;
 
+        // V2 UserMarketOrder: same `tokenID` / `side` / `amount` / `price`
+        // surface; `feeRateBps` / `nonce` / `taker` removed; `builder` and
+        // `metadata` populated by the SDK from `builderConfig`.
         const result = await client.createAndPostMarketOrder(
           {
             tokenID: params.tokenId,
@@ -717,6 +771,7 @@ export class TradingService {
       };
     }
 
+    this.ensureBuilderCode();
     const client = await this.ensureInitialized();
 
     return this.rateLimiter.execute(ApiType.CLOB_API, async () => {
@@ -1357,7 +1412,11 @@ export async function createBuilderApiKey(privateKey: string): Promise<BuilderKe
   const wallet = new Wallet(privateKey);
 
   // Step 1: L1 auth → derive or create L2 CLOB credentials
-  const l1Client = new ClobClient(CLOB_HOST, POLYGON_MAINNET as Chain, wallet);
+  const l1Client = new ClobClient({
+    host: CLOB_HOST,
+    chain: POLYGON_MAINNET as Chain,
+    signer: wallet,
+  });
 
   let clobCreds: ApiCredentials;
   const derived = await l1Client.deriveApiKey();
@@ -1375,12 +1434,12 @@ export async function createBuilderApiKey(privateKey: string): Promise<BuilderKe
   }
 
   // Step 2: L2 auth → create L3 Builder API key
-  const l2Client = new ClobClient(
-    CLOB_HOST,
-    POLYGON_MAINNET as Chain,
-    wallet,
-    { key: clobCreds.key, secret: clobCreds.secret, passphrase: clobCreds.passphrase },
-  );
+  const l2Client = new ClobClient({
+    host: CLOB_HOST,
+    chain: POLYGON_MAINNET as Chain,
+    signer: wallet,
+    creds: { key: clobCreds.key, secret: clobCreds.secret, passphrase: clobCreds.passphrase },
+  });
 
   const builderCreds = await l2Client.createBuilderApiKey();
   if (!builderCreds.key) {

--- a/src/utils/calldata-decoder.ts
+++ b/src/utils/calldata-decoder.ts
@@ -4,11 +4,27 @@
  * Decodes `matchOrders` calldata from pending/mined TXs to extract
  * maker/taker addresses, token IDs, and order details.
  *
- * Both CTF Router (0xE3f18aCc55091e2c48d883fc8C8413319d4Ab7b0) and
- * NegRisk Router (0xB768891e3130F6dF18214Ac804d4DB76c2C37730) use
- * the FeeModule's matchOrders with selector 0x2287e350.
+ * Two distinct ABIs are supported:
  *
- * @see https://github.com/Polymarket/exchange-fee-module
+ *   V1 (pre-2026-04-28 cutover): the V1 CTF Exchange + V1 NegRisk CTF
+ *   Exchange were proxied through a `FeeModule` (CTF Router /
+ *   NegRisk Router). The FeeModule's `matchOrders` selector is `0x2287e350`
+ *   and its 13-field Order tuple includes `taker`, `nonce`, `feeRateBps`.
+ *
+ *   V2 (post-2026-04-28 cutover): V2 CTF Exchange (`0xE111...`) and V2
+ *   NegRisk CTF Exchange (`0xe2222d...`) expose `matchOrders` directly with
+ *   selector `0x3c2b4399`. The 12-field SignedOrder tuple drops `taker` /
+ *   `nonce` / `feeRateBps` and adds `timestamp` (ms) / `metadata` (bytes32)
+ *   / `builder` (bytes32). Verified via on-chain selector probe + 4byte
+ *   directory + Polymarket V2 SDK source (`ExchangeOrderBuilderV2`).
+ *
+ * Default behaviour of {@link decodeMatchOrdersCalldata} is V2-first with
+ * automatic fallback to V1 — relevant for any caller still scanning
+ * pre-cutover historical settlement TXs (for retrospective copy-trading
+ * analytics, the V1 calldata never disappears from the chain).
+ *
+ * @see https://github.com/Polymarket/exchange-fee-module (V1 source)
+ * @see ../constants/v2-contracts.ts (V2 contract SSOT)
  */
 
 import { ethers } from 'ethers';
@@ -17,38 +33,113 @@ import { ethers } from 'ethers';
 // Constants
 // ============================================================
 
-/** CTF Router (FeeModule) — operators send settlement TXs here */
+/**
+ * V1 CTF Router (FeeModule) — V1-era operators sent settlement TXs here.
+ *
+ * @deprecated Retained for historical-calldata decoding only. V2 settlement
+ * goes directly to the V2 CTF Exchange (`POLYGON_CONTRACTS_V2.ctfExchange`).
+ */
 export const CTF_ROUTER = '0xE3f18aCc55091e2c48d883fc8C8413319d4Ab7b0';
-/** NegRisk Router (FeeModule) — operators send NegRisk settlement TXs here */
+
+/**
+ * V1 NegRisk Router (FeeModule).
+ *
+ * @deprecated Same caveat as `CTF_ROUTER`.
+ */
 export const NEG_RISK_ROUTER = '0xB768891e3130F6dF18214Ac804d4DB76c2C37730';
 
-/** Both routers use the same matchOrders selector */
-export const MATCH_ORDERS_SELECTOR = '0x2287e350';
+/** V1 FeeModule `matchOrders` selector — both V1 routers share this. */
+export const MATCH_ORDERS_SELECTOR_V1 = '0x2287e350';
 
-/** Set of router addresses (lowercase) for quick lookup */
+/**
+ * V2 CTF Exchange `matchOrders` selector.
+ *
+ * Verified via:
+ *   - On-chain bytecode probe of `0xE111180000d2663C0091e4f400237545B87B996B`
+ *   - 4byte / openchain.xyz signature lookup
+ *   - V2 SDK `ExchangeOrderBuilderV2` order struct (matches the tuple shape)
+ */
+export const MATCH_ORDERS_SELECTOR_V2 = '0x3c2b4399';
+
+/**
+ * @deprecated Backward-compat alias for `MATCH_ORDERS_SELECTOR_V1`. Existing
+ * callers (smart-money copy-trading) hard-code this constant; keeping the
+ * alias prevents an API break while V2 fixtures are integrated.
+ */
+export const MATCH_ORDERS_SELECTOR = MATCH_ORDERS_SELECTOR_V1;
+
+/**
+ * Set of router addresses (lowercase) for quick lookup.
+ *
+ * V1 routers ONLY — V2 settlement is direct-to-exchange (no router proxy).
+ * Use {@link isSettlementTx} for a router-aware check that includes V2
+ * exchange addresses.
+ */
 export const ROUTER_ADDRESSES = new Set([
   CTF_ROUTER.toLowerCase(),
   NEG_RISK_ROUTER.toLowerCase(),
 ]);
 
 // ============================================================
-// ABI
+// ABIs
 // ============================================================
 
-/** Order struct tuple type (13 fields per CTF Exchange Order struct) */
-const ORDER_TUPLE =
+/**
+ * V1 Order struct tuple (13 fields per CTF Exchange + FeeModule wrapper).
+ *
+ * Order: salt, maker, signer, taker, tokenId, makerAmount, takerAmount,
+ *        expiration, nonce, feeRateBps, side(uint8), signatureType(uint8),
+ *        signature(bytes).
+ */
+const ORDER_TUPLE_V1 =
   'tuple(uint256 salt, address maker, address signer, address taker, uint256 tokenId, uint256 makerAmount, uint256 takerAmount, uint256 expiration, uint256 nonce, uint256 feeRateBps, uint8 side, uint8 signatureType, bytes signature)';
 
 /**
- * FeeModule matchOrders ABI (7 params).
- * Selector: keccak256("matchOrders((uint256,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8,bytes),(uint256,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8,bytes)[],uint256,uint256,uint256[],uint256,uint256[])") = 0x2287e350
+ * V1 FeeModule matchOrders ABI (7 params after FeeModule wrapping).
+ *
+ * Selector: `0x2287e350` (verified).
  */
-const MATCH_ORDERS_IFACE = new ethers.utils.Interface([
+const MATCH_ORDERS_IFACE_V1 = new ethers.utils.Interface([
   `function matchOrders(
-    ${ORDER_TUPLE} takerOrder,
-    ${ORDER_TUPLE}[] makerOrders,
+    ${ORDER_TUPLE_V1} takerOrder,
+    ${ORDER_TUPLE_V1}[] makerOrders,
     uint256 takerFillAmount,
     uint256 makerFillAmount,
+    uint256[] makerFillAmounts,
+    uint256 takerFeeAmount,
+    uint256[] makerFeeAmounts
+  )`,
+]);
+
+/**
+ * V2 Order struct tuple (12 fields).
+ *
+ * Order: salt, maker, signer, tokenId, makerAmount, takerAmount,
+ *        side(uint8), signatureType(uint8), timestamp, metadata(bytes32),
+ *        builder(bytes32), signature(bytes).
+ *
+ * Differences from V1:
+ *   - REMOVED: `taker`, `expiration`, `nonce`, `feeRateBps`
+ *   - ADDED:   `timestamp` (uint256, ms), `metadata` (bytes32),
+ *              `builder` (bytes32 — for builder attribution)
+ */
+const ORDER_TUPLE_V2 =
+  'tuple(uint256 salt, address maker, address signer, uint256 tokenId, uint256 makerAmount, uint256 takerAmount, uint8 side, uint8 signatureType, uint256 timestamp, bytes32 metadata, bytes32 builder, bytes signature)';
+
+/**
+ * V2 CTF Exchange matchOrders ABI (7 params, taker direct on exchange).
+ *
+ * The leading `bytes32` is opaque to this decoder (likely a feature/preimage
+ * hash carried for refund accounting; not needed for trader attribution).
+ *
+ * Selector: `0x3c2b4399` (verified via 4byte + openchain).
+ */
+const MATCH_ORDERS_IFACE_V2 = new ethers.utils.Interface([
+  `function matchOrders(
+    bytes32 contextHash,
+    ${ORDER_TUPLE_V2} takerOrder,
+    ${ORDER_TUPLE_V2}[] makerOrders,
+    uint256 takerFillAmount,
     uint256[] makerFillAmounts,
     uint256 takerFeeAmount,
     uint256[] makerFeeAmounts
@@ -65,10 +156,17 @@ export enum OrderSide {
   SELL = 1,
 }
 
-/** Decoded order info (subset of fields relevant for copy-trading) */
+/**
+ * Decoded order info — common subset across V1 / V2.
+ *
+ * V1-only fields (`taker`) are surfaced as best-effort: V2 orders never carry
+ * a taker on-chain (any-taker is the only V2 model), so V2 decodes set it to
+ * the zero address.
+ */
 export interface DecodedOrder {
   maker: string;
   signer: string;
+  /** V1: explicit taker; V2: always zero address (`0x000…000`). */
   taker: string;
   tokenId: string;
   makerAmount: string;
@@ -76,21 +174,35 @@ export interface DecodedOrder {
   side: OrderSide;
 }
 
-/** Result of decoding matchOrders calldata */
+/** V2 adds `timestamp` (ms), `metadata`, `builder` fields. */
+export interface DecodedOrderV2 extends DecodedOrder {
+  /** Order timestamp in ms (V2-only; replaces V1 nonce as uniqueness). */
+  timestamp: string;
+  /** Application-defined metadata bytes32 (V2-only). */
+  metadata: string;
+  /** Builder code (bytes32) attributing this order to a builder (V2-only). */
+  builder: string;
+}
+
+/** Result of decoding matchOrders calldata (V1 or V2 — discriminated). */
 export interface DecodedMatchOrders {
+  /** Calldata version detected — 1 = V1 FeeModule, 2 = V2 direct exchange. */
+  version: 1 | 2;
   /** The taker (active) order */
-  takerOrder: DecodedOrder;
+  takerOrder: DecodedOrder | DecodedOrderV2;
   /** All maker (passive) orders */
-  makerOrders: DecodedOrder[];
+  makerOrders: Array<DecodedOrder | DecodedOrderV2>;
   takerFillAmount: string;
   makerFillAmounts: string[];
 }
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 // ============================================================
 // Decoder
 // ============================================================
 
-function decodeOrder(raw: any): DecodedOrder {
+function decodeOrderV1(raw: any): DecodedOrder {
   return {
     maker: raw.maker.toLowerCase(),
     signer: raw.signer.toLowerCase(),
@@ -102,17 +214,43 @@ function decodeOrder(raw: any): DecodedOrder {
   };
 }
 
+function decodeOrderV2(raw: any): DecodedOrderV2 {
+  return {
+    maker: raw.maker.toLowerCase(),
+    signer: raw.signer.toLowerCase(),
+    // V2 has no on-chain taker — surface zero address for symmetry
+    taker: ZERO_ADDRESS,
+    tokenId: raw.tokenId.toString(),
+    makerAmount: raw.makerAmount.toString(),
+    takerAmount: raw.takerAmount.toString(),
+    side: Number(raw.side) as OrderSide,
+    timestamp: raw.timestamp.toString(),
+    metadata: raw.metadata,
+    builder: raw.builder,
+  };
+}
+
 /**
- * Decode matchOrders calldata from a settlement TX.
- * Returns null if the data doesn't start with the matchOrders selector or decoding fails.
+ * V1-only decoder. Returns null if data doesn't start with the V1 selector
+ * or decoding fails.
+ *
+ * Use this when you know the calldata is V1 (e.g. historical replay /
+ * pre-cutover backfill). For unknown calldata, prefer
+ * {@link decodeMatchOrdersCalldata} which auto-detects.
  */
-export function decodeMatchOrdersCalldata(data: string): DecodedMatchOrders | null {
+export function decodeMatchOrdersCalldataV1(
+  data: string
+): DecodedMatchOrders | null {
   try {
-    if (!data.startsWith(MATCH_ORDERS_SELECTOR)) return null;
-    const decoded = MATCH_ORDERS_IFACE.decodeFunctionData('matchOrders', data);
+    if (!data.startsWith(MATCH_ORDERS_SELECTOR_V1)) return null;
+    const decoded = MATCH_ORDERS_IFACE_V1.decodeFunctionData(
+      'matchOrders',
+      data
+    );
     return {
-      takerOrder: decodeOrder(decoded.takerOrder),
-      makerOrders: decoded.makerOrders.map(decodeOrder),
+      version: 1,
+      takerOrder: decodeOrderV1(decoded.takerOrder),
+      makerOrders: decoded.makerOrders.map(decodeOrderV1),
       takerFillAmount: decoded.takerFillAmount.toString(),
       makerFillAmounts: decoded.makerFillAmounts.map((a: any) => a.toString()),
     };
@@ -122,7 +260,66 @@ export function decodeMatchOrdersCalldata(data: string): DecodedMatchOrders | nu
 }
 
 /**
- * Check if a TX is a settlement TX (sent to a Router contract).
+ * V2-only decoder. Returns null if data doesn't start with the V2 selector
+ * or decoding fails.
+ */
+export function decodeMatchOrdersCalldataV2(
+  data: string
+): DecodedMatchOrders | null {
+  try {
+    if (!data.startsWith(MATCH_ORDERS_SELECTOR_V2)) return null;
+    const decoded = MATCH_ORDERS_IFACE_V2.decodeFunctionData(
+      'matchOrders',
+      data
+    );
+    return {
+      version: 2,
+      takerOrder: decodeOrderV2(decoded.takerOrder),
+      makerOrders: decoded.makerOrders.map(decodeOrderV2),
+      takerFillAmount: decoded.takerFillAmount.toString(),
+      makerFillAmounts: decoded.makerFillAmounts.map((a: any) => a.toString()),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decode matchOrders calldata from a settlement TX — V2-first with V1
+ * fallback.
+ *
+ * Returns null if the data is neither a V2 nor V1 matchOrders calldata.
+ *
+ * Selection rule:
+ *   1. If the leading 4 bytes match `MATCH_ORDERS_SELECTOR_V2`, decode V2.
+ *   2. Else if they match `MATCH_ORDERS_SELECTOR_V1`, decode V1.
+ *   3. Else null.
+ *
+ * V2 decode failures do NOT silently fall through to V1 (selectors are
+ * exhaustive — if the V2 selector matches but the body is malformed, that's
+ * a bug, not a V1 calldata).
+ */
+export function decodeMatchOrdersCalldata(
+  data: string
+): DecodedMatchOrders | null {
+  if (data.startsWith(MATCH_ORDERS_SELECTOR_V2)) {
+    return decodeMatchOrdersCalldataV2(data);
+  }
+  if (data.startsWith(MATCH_ORDERS_SELECTOR_V1)) {
+    return decodeMatchOrdersCalldataV1(data);
+  }
+  return null;
+}
+
+/**
+ * Check if a TX is a settlement TX (sent to a V1 Router contract).
+ *
+ * NOTE: V2 settlement bypasses any router and goes direct to the V2 CTF
+ * Exchange / NegRisk CTF Exchange. To detect V2 settlement, check the `to`
+ * address against `POLYGON_CONTRACTS_V2.ctfExchange` /
+ * `POLYGON_CONTRACTS_V2.negRiskExchange` (or simply attempt
+ * {@link decodeMatchOrdersCalldata} on the calldata, which works for both
+ * versions).
  */
 export function isSettlementTx(to: string | null | undefined): boolean {
   return !!to && ROUTER_ADDRESSES.has(to.toLowerCase());


### PR DESCRIPTION
## 背景

Polymarket CLOB V2 已于 **2026-04-28 11:00 UTC** 上线。V1 SDK 与 V1-signed orders 在 production 已不再被接受 — **破坏性更新，没有向后兼容**。

本 PR 是 poly-sdk 的完整 V2 迁移，覆盖所有 SDK 层 V1→V2 改造。包含 4 个 commit（stage A → B → C → 3 P0 fixes from multi-perspective review），最终通过 154 tests + tsc clean + 4 视角 review。

参考：
- **迁移 SSOT**: \`earning-engine/.claude/skills/guide-polymarket-v2-migration/\`
- 详细方案: \`plans/02-poly-sdk-migration.md\`, \`plans/12-poly-sdk-pr-templates.md\`
- 4 视角 review reports: \`reviews/poly-sdk-v2-{correctness,safety,fidelity,completeness}.md\`
- audit: \`audits/01-poly-sdk-audit.md\` (closes 4 P0)

## 修改方案

### 1. SDK 包切换 (89f65d3 - stage A)

| 项 | V1 | V2 |
|---|---|---|
| 包 | \`@polymarket/clob-client@5.x\` | **\`@polymarket/clob-client-v2@1.0.3\`** |
| EIP-712 域 version | \`\"1\"\` | **\`\"2\"\`** (V2 SDK 自动 resolve) |
| ClobAuthDomain | \`\"1\"\` | \`\"1\"\` (不变) |
| 保留 | - | \`@polymarket/builder-signing-sdk\` (用于 Relayer gasless TX) |

新建 \`src/constants/v2-contracts.ts\` — V2 合约 + EIP-712 SSOT：

| 合约 | V2 地址 |
|---|---|
| CTF Exchange | \`0xE111180000d2663C0091e4f400237545B87B996B\` (changed) |
| NegRisk Exchange | \`0xe2222d279d744050d28e00520010520000310F59\` (changed) |
| NegRisk Adapter | \`0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296\` (**unchanged**) |
| pUSD | \`0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB\` |
| **Onramp** | \`0x93070a847efEf7F70739046A929D47a521F5B8ee\` (**on-chain verified**) |
| **Offramp** | \`0x2957922Eb93258b93368531d39fAcCA3B4dC5854\` (separate from pUSD) |

### 2. TradingService V2 (7e09210 - stage B)

- 6 处 \`new ClobClient(...)\` 全部转换为 V2 options-bag (\`chainId\` → \`chain\`)
- Order Struct V2: 移除 \`nonce\`/\`feeRateBps\`/\`taker\`，添加 \`timestamp(ms)\`/\`metadata\`/\`builder(bytes32)\`
- Builder 认证拆分: \`builderCode\` (bytes32) for order signing; HMAC creds 仍用于 Relayer
- 新建 \`src/constants/builder-config.ts\` — \`POLY_BUILDER_CODE\` env 验证 + \`ensureBuilderCode()\` fail-fast 门
- 移除 V1 SDK package
- 20 新单元测试

### 3. Wrap + Approvals + Calldata V2 (2f52712 - stage C)

- \`RelayerService.wrapUsdcToPUSD()\` + \`unwrapPUSDtoUsdc()\` (USDC.e ↔ pUSD via Onramp/Offramp)
- \`AuthorizationService\` V2 spenders 矩阵（4 ERC20 + 3 ERC1155，token-aware: pUSD vs USDC.e）
- \`calldata-decoder\` V1/V2 dual decoder (V2 selector \`0x3c2b4399\`, V1 selector \`0x2287e350\`, auto-detect with V1 fallback)
- 32 新单元测试

### 4. 3 P0 Fixes from 4-perspective review (09bc31c)

- **Fidelity P0** (`builderCreds` silent drop): SDK constructor 现在 throw clear migration error if `builderCreds` present without `builderCode`
- **Completeness P0-A** (relayer V1 collateral): 6 个 relayer 函数 (\`split / merge / redeem / redeemBatch / approveUsdc / transferUsdc\`) 添加 \`token: 'pUSD' | 'USDC.e'\` 参数，默认 'pUSD'
- **Completeness P0-C** (ctf-client V1 addrs): \`CTF_EXCHANGE\` → \`CTF_EXCHANGE_V1_DEPRECATED\` (alias preserved with @deprecated JSDoc) + 新 \`_V2\` exports
- 17 新单元测试

## 数据流

### 修改前 (V1)

\`\`\`
strategy → TradingService.placeOrder()
  ├── ClobClient V1 (positional ctor)
  ├── EIP-712 sign with domain v1
  ├── HMAC headers (POLY_BUILDER_API_KEY/SECRET/PASSPHRASE)
  └── POST /order to CLOB

钱包 ops → RelayerService
  ├── HMAC envelope sign
  └── POST /relayer-tx (使用 USDC.e 作 collateral)
\`\`\`

### 修改后 (V2)

\`\`\`
strategy → TradingService.placeOrder()
  ├── ClobClient V2 (options-bag ctor: chain, builderConfig: { builderCode })
  ├── EIP-712 sign with domain v2 (auto-resolved by V2 SDK)
  ├── Order struct includes builder bytes32 from POLY_BUILDER_CODE env
  └── POST /order to CLOB

钱包 ops → RelayerService
  ├── HMAC envelope sign (path 不变)
  ├── token: 'pUSD' (default for V2 trading) or 'USDC.e' (fund-out only)
  └── wrapUsdcToPUSD / unwrapPUSDtoUsdc via Onramp/Offramp
\`\`\`

## 测试

| 项 | 数量 | 状态 |
|----|------|------|
| Baseline tests (V1 era) | 85 | ✅ pass |
| V2 builder-config | 13 | ✅ pass |
| V2 trading-service-init | 7 | ✅ pass |
| V2 relayer-wrap | 9 | ✅ pass |
| V2 authorization | 7 | ✅ pass |
| V2 calldata-decoder | 16 | ✅ pass |
| **V2 trading-service-init (P0 fix +)** | 11 | ✅ pass |
| V2 relayer-token-routing (P0 fix) | 13 | ✅ pass |
| **总计** | **154** | **✅ all pass** |

- \`npx tsc --noEmit\` → **0 errors**
- \`pnpm build\` → clean
- \`pnpm test\` duration: 9.17s

## 4 视角 Review 结果

| 视角 | GATE | 关键 finding |
|------|------|------|
| **Correctness** | ✅ pass | 0 P0 / 0 P1 / 3 P2 polish (all V2 claims verified via SDK source + on-chain bytecode + ethers selector probe) |
| **Safety** | 🟡 conditional GO | poly-sdk PR 本身 safe to merge; production wrap 需先 ship Plan 11 §1 PM2 halt + §2 revoke CLI + §8 idempotency (Plan 11 已 backlog) |
| **Fidelity** | ✅ fixed | 1 P0 silent-break (\`builderCreds\` drop) — fixed in 09bc31c |
| **Completeness** | 🟡 partial | 4 P0; 3 fixed in 09bc31c; 1 deferred (smart-money mempool V1 selector — known issue, earning-engine layer follow-up) + 1 noted (Unwrap Offramp approval — Plan 11 §6) |

详见 \`reviews/poly-sdk-v2-{correctness,safety,fidelity,completeness}.md\`。

## 已知遗留 (out of scope, follow-up)

- **Smart-money mempool V2 selector support**: \`smart-money/monitor.ts\` 仍用 V1 router + V1 selector — 滤掉 V2 settlement TX。Smart-money 不在 trading 关键路径，不影响本 PR merge。Earning-engine 层 follow-up。
- **Unwrap Offramp approval not in default approveAll()**: documented in code comments + Plan 11 §6 + \`ee wallet reapprove --include-offramp\` flag (待 earning-engine 层加)
- **3 P2 polish from correctness**: Offramp pre-approval ergonomics / tradingReady semantics / decoder field projection — 后续小 PR
- **2 P1 from fidelity**: \`approveUsdc\` API rename / \`AllowancesResult.usdcBalance\` alias semantics — earning-engine 层调用方需 audit
- **2 P2 from fidelity**: V2 tests surface-only / RelayerService.approveUsdc hardcoded USDC.e (still — different method) — follow-up

## 风险与回滚

### 行为变化
- 全 V2 SDK：所有 V1 SDK 调用站已迁移
- \`approveUsdc\` 默认 token 从 USDC.e → pUSD（V2 trading collateral）— **breaking** for callers expecting old default
- \`AllowancesResult.usdcBalance\` 从字面 USDC.e balance → pUSD balance alias — **breaking** for readers
- Order timestamp 从 seconds → milliseconds (内部由 V2 SDK 自动处理)

### 回滚
- 单 commit revert + submodule pointer 回退到 \`7c8c7b4\` (copy-trading base before V2 work)
- 因为 poly-sdk 是 submodule, earning-engine 端只需 bump pointer

## Self-review checklist

- [x] §A Universal: 代码 grep 无 V1 残留 / tests pass / typecheck / build / commit messages
- [x] §B Code-change: helper isolation / backward compat (deprecated alias 保留) / boundary tests / numerical sanity / SDK 源码引用
- [x] §C High-risk: 4 视角 evaluate 完成 / pre-condition checks / rollback steps / 测试覆盖

## 关闭 audit Q

本 PR 关闭：
- Q1 pUSD 地址 ✅ (\`0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB\`)
- Q2 Onramp 地址 ✅ (\`0x93070a847efEf7F70739046A929D47a521F5B8ee\` + Offramp \`0x2957922eB9...\`)
- Q3 NegRisk Adapter ✅ (unchanged from V1)
- Q4 CTF Router V2 ✅ (V2 settles direct-to-exchange, no router proxy)
- Q5 WS USER_TRADE feeRateBps ✅ (V2 SDK 自动处理)
- Q6 \`@polymarket/clob-client-v2\` published ✅ (1.0.3 on npm)
- Q7 builder code sourcing ✅ (\`POLY_BUILDER_CODE\` env)
- Q9 V2 sandbox ✅ (no testnet)
- Q11 Onramp ABI ✅ (\`wrap(address,address,uint256)\`)

仍 open: Q8 (test market fee rate, Phase 6 production validation), Q10 (\`feeExponent\` per-market verification, Phase 6 前查 \`getMarket\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)