### PR TITLE
chore(v2): 清理 V2 不再消费的 builderCreds dead surfaces

### DIFF
--- a/src/__tests__/unit/v2-trading-service-init.test.ts
+++ b/src/__tests__/unit/v2-trading-service-init.test.ts
@@ -14,7 +14,6 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TradingService } from '../../services/trading-service.js';
 import { RateLimiter } from '../../core/rate-limiter.js';
 import { createUnifiedCache } from '../../core/unified-cache.js';
-import { PolymarketSDK } from '../../index.js';
 
 const ENV_KEY = 'POLY_BUILDER_CODE';
 const VALID_PK = '0x' + '1'.repeat(64);
@@ -112,61 +111,9 @@ describe('TradingService V2 — builder-code gating', () => {
   });
 });
 
-describe('PolymarketSDK V2 — builderCreds without builderCode is fail-fast', () => {
-  let prev: string | undefined;
-
-  beforeEach(() => {
-    prev = process.env.POLY_BUILDER_CODE;
-    delete process.env.POLY_BUILDER_CODE;
-  });
-
-  afterEach(() => {
-    if (prev === undefined) {
-      delete process.env.POLY_BUILDER_CODE;
-    } else {
-      process.env.POLY_BUILDER_CODE = prev;
-    }
-  });
-
-  it('throws clear migration error when builderCreds provided but builderCode missing', () => {
-    expect(
-      () =>
-        new PolymarketSDK({
-          privateKey: VALID_PK,
-          builderCreds: { key: 'k', secret: 's', passphrase: 'p' },
-        })
-    ).toThrow(/builderCreds.*builderCode|POLY_BUILDER_CODE/);
-  });
-
-  it('does not throw when both builderCreds and builderCode are provided', () => {
-    expect(
-      () =>
-        new PolymarketSDK({
-          privateKey: VALID_PK,
-          builderCreds: { key: 'k', secret: 's', passphrase: 'p' },
-          builderCode: VALID_BUILDER_CODE,
-        })
-    ).not.toThrow();
-  });
-
-  it('does not throw when builderCreds is omitted (relayer-less paths)', () => {
-    expect(
-      () =>
-        new PolymarketSDK({
-          privateKey: VALID_PK,
-          builderCode: VALID_BUILDER_CODE,
-        })
-    ).not.toThrow();
-  });
-
-  it('accepts builderCreds when POLY_BUILDER_CODE env supplies the code', () => {
-    process.env.POLY_BUILDER_CODE = VALID_BUILDER_CODE;
-    expect(
-      () =>
-        new PolymarketSDK({
-          privateKey: VALID_PK,
-          builderCreds: { key: 'k', secret: 's', passphrase: 'p' },
-        })
-    ).not.toThrow();
-  });
-});
+// NOTE: The 4 PolymarketSDK fail-fast tests covering `builderCreds` without
+// `builderCode` were removed alongside the `PolymarketSDKConfig.builderCreds`
+// field itself (chore/v2-cleanup-builder-creds, 2026-05-05). After the V2
+// cutover that field carried no behaviour — HMAC creds are now consumed only
+// by `RelayerService`, instantiated directly. The fail-fast guard had nothing
+// left to guard.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -267,26 +267,17 @@ export interface PolySDKOptions {
   mempoolWssUrl?: string;
 
   /**
-   * Builder API credentials (HMAC three-tuple) for the **Relayer / gasless TX**
-   * envelope path (`@polymarket/builder-signing-sdk`). Still required after the
-   * 2026-04-28 V2 cutover for Safe deployment / approvals / fund movement.
-   *
-   * NOTE: V2 order signing no longer uses HMAC creds — order attribution is
-   * now carried by the bytes32 `builderCode` (see `builderCode` below). Pass
-   * both fields when running a full Builder flow.
-   */
-  builderCreds?: {
-    key: string;
-    secret: string;
-    passphrase: string;
-  };
-
-  /**
    * V2 builder code (bytes32, e.g. `0x...64hex`). Embedded in every signed
    * order's `Order.builder` field for on-chain attribution. Falls back to the
    * `POLY_BUILDER_CODE` env var when omitted.
    *
    * Required for any path that places orders post-2026-04-28 cutover.
+   *
+   * NOTE: HMAC builder creds (`{ key, secret, passphrase }`) are NO LONGER
+   * accepted on this config. After the V2 cutover they are only consumed by
+   * `RelayerService` for gasless TX envelopes (Safe deploy / wrap / transfer);
+   * instantiate `RelayerService` directly with `RelayerServiceConfig.builderCreds`
+   * if you need that path.
    */
   builderCode?: string;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -647,36 +647,12 @@ export class PolymarketSDK {
   private _initialized = false;
 
   constructor(config: PolymarketSDKConfig = {}) {
-    // -----------------------------------------------------------------------
-    // V2 migration guard: fail-fast if caller still relies on V1-style HMAC
-    // creds for order signing.
-    //
-    // Background: pre-V2, `builderCreds` (HMAC three-tuple) flowed into the
-    // trading path and produced a HMAC-signed builder header. Post-2026-04-28
-    // V2 cutover, order attribution moved to a bytes32 `builderCode` embedded
-    // directly in the order struct, and HMAC creds are only used for the
-    // Relayer / gasless TX path. TypeScript's structural typing still accepts
-    // an old `{ builderCreds }` config object on `PolymarketSDKConfig` (the
-    // field stays on `PolySDKOptions` because Relayer needs it), so without
-    // an explicit guard the SDK silently drops the old auth and the first
-    // signed order surfaces the V1→V2 drift only at runtime.
-    //
-    // We require: when `builderCreds` is supplied, `builderCode` (or the
-    // `POLY_BUILDER_CODE` env) MUST also be supplied. This catches the
-    // ambiguous "still on the V1 mental model" call sites without breaking
-    // pure-Relayer setups (which would normally not pass `builderCreds`
-    // through `PolymarketSDK`'s constructor anyway).
-    // -----------------------------------------------------------------------
-    if (config.builderCreds && !config.builderCode && !process.env.POLY_BUILDER_CODE) {
-      throw new Error(
-        'PolymarketSDK: `builderCreds` (V1 HMAC three-tuple) is no longer used ' +
-        'for order signing after the 2026-04-28 V2 cutover. Order attribution ' +
-        'is now carried by the bytes32 `builderCode` (Order.builder field). ' +
-        'Set the POLY_BUILDER_CODE env var (32-byte hex) or pass ' +
-        '`builderCode` in `PolymarketSDKConfig` alongside `builderCreds`. ' +
-        'See guide-polymarket-v2-migration for the full migration path.'
-      );
-    }
+    // V2 cutover (2026-04-28): order attribution is carried by the bytes32
+    // `builderCode` (Order.builder field), not by HMAC builder creds. The
+    // `PolymarketSDKConfig.builderCreds` field has been removed — HMAC creds
+    // are now only consumed by `RelayerService` directly for gasless TX
+    // envelopes (Safe deploy / wrap / transfer).
+    // See guide-polymarket-v2-migration for the full migration path.
 
     // Initialize infrastructure
     this.rateLimiter = new RateLimiter();
@@ -694,9 +670,8 @@ export class PolymarketSDK {
       privateKey,
       chainId: config.chainId,
       credentials: config.creds,
-      // V2: order signing uses `builderCode` (bytes32). HMAC `builderCreds`
-      // are still on the SDK options (for Relayer), but no longer flow into
-      // the trading path.
+      // V2: order signing uses `builderCode` (bytes32) — HMAC creds belong
+      // to `RelayerService`, not the trading path.
       builderCode: config.builderCode,
       safeAddress: config.safeAddress,
       dataApi: this.dataApi,

--- a/src/services/order-manager.ts
+++ b/src/services/order-manager.ts
@@ -214,12 +214,6 @@ export interface OrderManagerConfig {
   /** RPC URL for Polygon provider (for settlement tracking) */
   polygonRpcUrl?: string;
   /**
-   * Builder API HMAC credentials. Retained on the OrderManager surface for
-   * compatibility / Relayer-side flows; **not** consumed by V2 order signing
-   * (use `builderCode` instead).
-   */
-  builderCreds?: { key: string; secret: string; passphrase: string };
-  /**
    * V2 builder code (bytes32). Embedded in every signed order's `builder`
    * field on V2. Falls back to `POLY_BUILDER_CODE` env var when omitted.
    */
@@ -702,7 +696,7 @@ export class OrderManager extends EventEmitter {
   private polygonProvider: ethers.providers.Provider | null = null;
 
   // ========== Configuration ==========
-  private config: Required<Omit<OrderManagerConfig, 'builderCreds' | 'builderCode' | 'safeAddress'>> & Pick<OrderManagerConfig, 'builderCreds' | 'builderCode' | 'safeAddress'>;
+  private config: Required<Omit<OrderManagerConfig, 'builderCode' | 'safeAddress'>> & Pick<OrderManagerConfig, 'builderCode' | 'safeAddress'>;
   private initialized = false;
 
   // ========== Monitoring State ==========
@@ -734,9 +728,9 @@ export class OrderManager extends EventEmitter {
     const cache = config.cache || createUnifiedCache();
 
     // Initialize TradingService (always needed)
-    // V2: order signing reads `builderCode` (bytes32) — HMAC `builderCreds`
-    // are no longer threaded into TradingService, but remain on the
-    // OrderManagerConfig for upstream Relayer flows.
+    // V2: order signing reads `builderCode` (bytes32). HMAC creds are no
+    // longer threaded through OrderManager — RelayerService owns that path
+    // directly (gasless TX envelopes for deploy/wrap/transfer).
     this.tradingService = new TradingService(
       rateLimiter,
       cache,


### PR DESCRIPTION
## 背景

V2 migration PR #29 (e5f00c3) 完成后，user 发现 \`builderCreds\` (V1 HMAC) 仍残留在多个 V2 不再消费的 surface — 应清理。

## 决策

| § | 字段 | 决策 | 理由 |
|---|------|------|------|
| 1 | \`OrderManagerConfig.builderCreds\` | **REMOVED** | 注释确认 V2 不消费，纯 dead |
| 2 | \`TradingService.createBuilderApiKey()\` / \`BuilderKeyResult.builderCreds\` | **KEPT** | mirror 上游 Polymarket SDK 命名 + earning-engine \`wallet/file-wallet-store.ts\` 持久化到 JSON; 重命名 = cross-repo refactor + disk format migration |
| 3 | \`PolymarketSDKConfig.builderCreds\` | **REMOVED** | 调研发现该字段从未被 thread 到 RelayerService — 唯一用途是触发 fail-fast guard. 所有 earning-engine \`new PolymarketSDK()\` callsite 传空 config, RelayerService 直接构造 |
| 4 | \`index.ts\` fail-fast guard | **REMOVED** | §3 移除后 unreachable |
| 5 | 测试更新 | 删除 4 个 obsolete fail-fast tests | v2-relayer-wrap / v2-relayer-token-routing 不动 (那些 \`builderCreds\` 是 \`RelayerServiceConfig\`，仍是合法 V2 surface) |

## 改动

- 4 files / -93 净行 (24 insert / 117 delete)
- \`src/core/types.ts\` — 移除 PolymarketSDKConfig.builderCreds + 加 builderCode migration 注释
- \`src/index.ts\` — 移除 30 行 fail-fast guard，留 7 行 migration 注释
- \`src/services/order-manager.ts\` — 移除 OrderManagerConfig.builderCreds + Pick<> 引用 + 注释更新
- \`src/__tests__/unit/v2-trading-service-init.test.ts\` — 移除 4 fail-fast tests + NOTE 说明原因

## 测试

- \`npx tsc --noEmit\` → 0 errors
- \`pnpm test\` → 150 tests pass (was 154; -4 obsolete fail-fast tests for deleted field)
- \`pnpm build\` → clean

## 风险与回滚

**风险 LOW**: earning-engine 不通过 \`PolymarketSDK\` 构造器 thread \`builderCreds\` (verified by cross-repo grep)。所有 Relayer 流程直接构造 \`RelayerService\`。

**回滚**: \`git revert 4347097a\` 单 commit。

## Out-of-scope finding

预存在 TS error at \`earning-engine/trading-engine/src/impl/live-order-executor.ts:67\` — passes excess property \`builderCreds\` to \`TradingServiceConfig\`. 不在本 PR scope (poly-sdk only)，flag 给 earning-engine layer follow-up (Plan 11 §5 cleanup pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)