### PR TITLE
feat(smart-money): 接受 V1 routers + V2 exchanges in mempool filter (Plan 11 §6)

### DIFF
--- a/src/__tests__/unit/v2-smart-money-monitor-filter.test.ts
+++ b/src/__tests__/unit/v2-smart-money-monitor-filter.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Plan 11 §6 — Smart-money mempool filter accepts V1 routers AND V2 exchanges.
+ *
+ * `TradeMonitor` (poly-sdk smart-money) filters mempool TXs by:
+ *   1. `tx.to` ∈ allowed settlement recipients
+ *   2. `tx.input` starts with a known matchOrders selector
+ *
+ * V1 (pre-2026-04-28): tx.to = CTF Router / NegRisk Router, selector = 0x2287e350
+ * V2 (post-2026-04-28): tx.to = V2 CTF Exchange / NegRisk Exchange, selector = 0x3c2b4399
+ *
+ * This test exercises the filter end-to-end via `handleMempoolMessage` (private)
+ * by spinning a TradeMonitor without a real WS, watching a target trader, and
+ * pushing fabricated V1 + V2 mempool payloads. It verifies the monitor emits
+ * a `trade` event for the target trader on BOTH calldata versions and ignores
+ * non-settlement TXs.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ethers } from 'ethers';
+
+import { TradeMonitor } from '../../smart-money/monitor.js';
+import type { DataApiClient } from '../../clients/data-api.js';
+import {
+  CTF_ROUTER,
+  MATCH_ORDERS_SELECTOR_V1,
+  MATCH_ORDERS_SELECTOR_V2,
+} from '../../utils/calldata-decoder.js';
+import { POLYGON_CONTRACTS_V2 } from '../../constants/v2-contracts.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TARGET_TRADER = '0x000000000000000000000000000000000000aaaa';
+const COUNTERPARTY = '0x000000000000000000000000000000000000bbbb';
+const V2_TARGET_TRADER = '0x000000000000000000000000000000000000cccc';
+const V2_COUNTERPARTY = '0x000000000000000000000000000000000000dddd';
+
+const V1_TUPLE =
+  'tuple(uint256 salt, address maker, address signer, address taker, uint256 tokenId, uint256 makerAmount, uint256 takerAmount, uint256 expiration, uint256 nonce, uint256 feeRateBps, uint8 side, uint8 signatureType, bytes signature)';
+
+const V1_IFACE = new ethers.utils.Interface([
+  `function matchOrders(${V1_TUPLE} takerOrder, ${V1_TUPLE}[] makerOrders, uint256 takerFillAmount, uint256 makerFillAmount, uint256[] makerFillAmounts, uint256 takerFeeAmount, uint256[] makerFeeAmounts)`,
+]);
+
+const V2_TUPLE =
+  'tuple(uint256 salt, address maker, address signer, uint256 tokenId, uint256 makerAmount, uint256 takerAmount, uint8 side, uint8 signatureType, uint256 timestamp, bytes32 metadata, bytes32 builder, bytes signature)';
+
+const V2_IFACE = new ethers.utils.Interface([
+  `function matchOrders(bytes32 contextHash, ${V2_TUPLE} takerOrder, ${V2_TUPLE}[] makerOrders, uint256 takerFillAmount, uint256[] makerFillAmounts, uint256 takerFeeAmount, uint256[] makerFeeAmounts)`,
+]);
+
+function buildV1Calldata(): string {
+  const taker = {
+    salt: 1n,
+    maker: TARGET_TRADER,
+    signer: TARGET_TRADER,
+    taker: '0x0000000000000000000000000000000000000000',
+    tokenId: 12345n,
+    makerAmount: 1_000_000n, // 1 USDC
+    takerAmount: 2_000_000n, // 2 shares
+    expiration: 0n,
+    nonce: 0n,
+    feeRateBps: 100n,
+    side: 0, // BUY
+    signatureType: 0,
+    signature: '0x',
+  };
+  const maker = { ...taker, maker: COUNTERPARTY, signer: COUNTERPARTY, side: 1 };
+  return V1_IFACE.encodeFunctionData('matchOrders', [
+    taker,
+    [maker],
+    1_000_000n,
+    2_000_000n,
+    [1_000_000n],
+    0n,
+    [0n],
+  ]);
+}
+
+function buildV2Calldata(): string {
+  const taker = {
+    salt: 99n,
+    maker: V2_TARGET_TRADER,
+    signer: V2_TARGET_TRADER,
+    tokenId: 7777n,
+    makerAmount: 5_000_000n,
+    takerAmount: 8_000_000n,
+    side: 0, // BUY
+    signatureType: 2,
+    timestamp: 1714435200000n,
+    metadata: '0x' + '11'.repeat(32),
+    builder: '0x' + '22'.repeat(32),
+    signature: '0xabcd',
+  };
+  const maker = {
+    ...taker,
+    maker: V2_COUNTERPARTY,
+    signer: V2_COUNTERPARTY,
+    side: 1,
+  };
+  return V2_IFACE.encodeFunctionData('matchOrders', [
+    '0x' + 'ff'.repeat(32),
+    taker,
+    [maker],
+    5_000_000n,
+    [5_000_000n],
+    0n,
+    [0n],
+  ]);
+}
+
+function makeMempoolMessage(tx: {
+  to: string;
+  input: string;
+  hash?: string;
+}): Buffer {
+  return Buffer.from(
+    JSON.stringify({
+      params: {
+        result: {
+          to: tx.to,
+          input: tx.input,
+          hash: tx.hash ?? `0x${'a'.repeat(64)}`,
+        },
+      },
+    }),
+  );
+}
+
+// Minimal DataApiClient stub — TradeMonitor doesn't poll in these tests.
+const stubDataApi = {
+  getActivity: vi.fn(),
+} as unknown as DataApiClient;
+
+describe('Plan 11 §6 — TradeMonitor V1 + V2 settlement filter', () => {
+  let monitor: TradeMonitor;
+
+  beforeEach(() => {
+    monitor = new TradeMonitor(stubDataApi);
+  });
+
+  it('emits trade for V2 calldata sent to V2 CTF Exchange', () => {
+    const trades: any[] = [];
+    monitor.on('trade', (e) => trades.push(e));
+    monitor.watch([V2_TARGET_TRADER], 'mempool');
+
+    const msg = makeMempoolMessage({
+      to: POLYGON_CONTRACTS_V2.ctfExchange,
+      input: buildV2Calldata(),
+    });
+
+    (monitor as any).handleMempoolMessage(msg);
+
+    expect(trades).toHaveLength(1);
+    expect(trades[0].address).toBe(V2_TARGET_TRADER);
+    expect(trades[0].source).toBe('mempool');
+
+    monitor.stop();
+  });
+
+  it('emits trade for V2 calldata sent to V2 NegRisk Exchange', () => {
+    const trades: any[] = [];
+    monitor.on('trade', (e) => trades.push(e));
+    monitor.watch([V2_TARGET_TRADER], 'mempool');
+
+    const msg = makeMempoolMessage({
+      to: POLYGON_CONTRACTS_V2.negRiskExchange,
+      input: buildV2Calldata(),
+    });
+
+    (monitor as any).handleMempoolMessage(msg);
+
+    expect(trades).toHaveLength(1);
+    expect(trades[0].address).toBe(V2_TARGET_TRADER);
+
+    monitor.stop();
+  });
+
+  it('still decodes legacy V1 calldata sent to V1 CTF Router', () => {
+    const trades: any[] = [];
+    monitor.on('trade', (e) => trades.push(e));
+    monitor.watch([TARGET_TRADER], 'mempool');
+
+    const msg = makeMempoolMessage({
+      to: CTF_ROUTER,
+      input: buildV1Calldata(),
+    });
+
+    (monitor as any).handleMempoolMessage(msg);
+
+    expect(trades).toHaveLength(1);
+    expect(trades[0].address).toBe(TARGET_TRADER);
+
+    monitor.stop();
+  });
+
+  it('skips TX sent to a non-settlement recipient (random EOA)', () => {
+    const trades: any[] = [];
+    monitor.on('trade', (e) => trades.push(e));
+    monitor.watch([V2_TARGET_TRADER], 'mempool');
+
+    const msg = makeMempoolMessage({
+      to: '0x1234567890123456789012345678901234567890',
+      input: buildV2Calldata(),
+    });
+
+    (monitor as any).handleMempoolMessage(msg);
+
+    expect(trades).toHaveLength(0);
+
+    monitor.stop();
+  });
+
+  it('skips TX with non-matchOrders calldata sent to V2 exchange', () => {
+    const trades: any[] = [];
+    monitor.on('trade', (e) => trades.push(e));
+    monitor.watch([V2_TARGET_TRADER], 'mempool');
+
+    const msg = makeMempoolMessage({
+      to: POLYGON_CONTRACTS_V2.ctfExchange,
+      input: '0xdeadbeef' + '00'.repeat(32), // unknown selector
+    });
+
+    (monitor as any).handleMempoolMessage(msg);
+
+    expect(trades).toHaveLength(0);
+
+    monitor.stop();
+  });
+
+  it('selectors are the documented V1/V2 values', () => {
+    // Sanity that we wired the right constants into the monitor.
+    expect(MATCH_ORDERS_SELECTOR_V1).toBe('0x2287e350');
+    expect(MATCH_ORDERS_SELECTOR_V2).toBe('0x3c2b4399');
+    expect(buildV1Calldata().slice(0, 10)).toBe(MATCH_ORDERS_SELECTOR_V1);
+    expect(buildV2Calldata().slice(0, 10)).toBe(MATCH_ORDERS_SELECTOR_V2);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -570,11 +570,16 @@ export type { TickSize } from './utils/price-utils.js';
 // Calldata decoder (for mempool pending TX decoding — copy-trading)
 export {
   decodeMatchOrdersCalldata,
+  decodeMatchOrdersCalldataV1,
+  decodeMatchOrdersCalldataV2,
   isSettlementTx,
   extractTraderAddresses,
   CTF_ROUTER,
   NEG_RISK_ROUTER,
+  /** @deprecated alias of MATCH_ORDERS_SELECTOR_V1 — use the explicit version. */
   MATCH_ORDERS_SELECTOR,
+  MATCH_ORDERS_SELECTOR_V1,
+  MATCH_ORDERS_SELECTOR_V2,
   ROUTER_ADDRESSES,
   OrderSide,
 } from './utils/calldata-decoder.js';

--- a/src/smart-money/monitor.ts
+++ b/src/smart-money/monitor.ts
@@ -12,11 +12,43 @@ import type { TradeEvent, MonitorOptions } from './types.js';
 import { createModuleLogger } from '../core/logger.js';
 import {
   ROUTER_ADDRESSES,
-  MATCH_ORDERS_SELECTOR,
+  MATCH_ORDERS_SELECTOR_V1,
+  MATCH_ORDERS_SELECTOR_V2,
   decodeMatchOrdersCalldata,
   extractTraderAddresses,
   OrderSide,
 } from '../utils/calldata-decoder.js';
+import { POLYGON_CONTRACTS_V2 } from '../constants/v2-contracts.js';
+
+/**
+ * Plan 11 §6 — Settlement TX recipient whitelist.
+ *
+ * Mempool TXs filter on `tx.to` to skip non-settlement traffic before
+ * paying for calldata decode. V1 settlement went through router proxies
+ * (CTF Router / NegRisk Router); V2 settlement goes direct to the V2
+ * exchanges (CTF Exchange / NegRisk CTF Exchange).
+ *
+ * Both V1 and V2 are accepted so the historical-replay path keeps working
+ * during the cutover window when the mempool may carry pending V1 TXs
+ * that were broadcast before 2026-04-28 + still in flight.
+ */
+const SETTLEMENT_RECIPIENTS = new Set<string>([
+  ...Array.from(ROUTER_ADDRESSES),
+  POLYGON_CONTRACTS_V2.ctfExchange.toLowerCase(),
+  POLYGON_CONTRACTS_V2.negRiskExchange.toLowerCase(),
+]);
+
+/**
+ * Both V1 (`0x2287e350`) and V2 (`0x3c2b4399`) `matchOrders` selectors.
+ * `decodeMatchOrdersCalldata` auto-detects the version from the leading
+ * 4 bytes; this prefix gate is just to skip non-settlement calldata cheaply.
+ */
+function hasMatchOrdersSelector(input: string): boolean {
+  return (
+    input.startsWith(MATCH_ORDERS_SELECTOR_V2) ||
+    input.startsWith(MATCH_ORDERS_SELECTOR_V1)
+  );
+}
 
 const log = createModuleLogger('sm-monitor');
 
@@ -246,8 +278,10 @@ export class TradeMonitor extends EventEmitter {
       }
 
       if (typeof tx === 'string') return;
-      if (!tx.to || !ROUTER_ADDRESSES.has(tx.to.toLowerCase())) return;
-      if (!tx.input || !tx.input.startsWith(MATCH_ORDERS_SELECTOR)) return;
+      // Plan 11 §6 — accept BOTH V1 routers (legacy mempool tail) and V2
+      // exchanges (post-cutover). Calldata decode below is V2-aware too.
+      if (!tx.to || !SETTLEMENT_RECIPIENTS.has(tx.to.toLowerCase())) return;
+      if (!tx.input || !hasMatchOrdersSelector(tx.input)) return;
 
       const decoded = decodeMatchOrdersCalldata(tx.input);
       if (!decoded) return;


### PR DESCRIPTION
## 背景

V2 cutover 后，smart-money mempool monitor 仍仅接受 V1 ROUTER_ADDRESSES + V1 \`MATCH_ORDERS_SELECTOR\` (\`0x2287e350\`)，导致所有 V2 settlement TX (走 V2 CTF Exchange direct, selector \`0x3c2b4399\`) 被滤掉。

参考: \`earning-engine/.claude/skills/guide-polymarket-v2-migration/plans/11-safety-hardening.md\` §6, p0-fix-log P0-11

## 修改方案

\`smart-money/monitor.ts\`:
- 扩展 \`SETTLEMENT_RECIPIENTS\`: V1 routers + V2 CTF Exchange (\`0xE111180000d2663C0091e4f400237545B87B996B\`) + V2 NegRisk Exchange (\`0xe2222d279d744050d28e00520010520000310F59\`)
- 双 selector 检查: V1 \`0x2287e350\` + V2 \`0x3c2b4399\`
- 通过 \`MATCH_ORDERS_SELECTOR_V1\` / \`MATCH_ORDERS_SELECTOR_V2\` 从 \`utils/calldata-decoder\` re-export
- index.ts 顶层导出新 selector 名

## 数据流

修改后:
\`\`\`
mempool tx → smart-money/monitor.ts.processTx()
  ├── recipient ∈ {V1 routers, V2 CTF Exchange, V2 NegRisk Exchange} ?
  │     └── if no → 跳过 (filter)
  ├── selector ∈ {V1 0x2287e350, V2 0x3c2b4399} ?
  │     └── if no → 跳过
  └── decodeMatchOrdersCalldata() 自动 V2-first / V1-fallback (已在 PR #29 实施)
\`\`\`

## 测试

新单元测试 \`v2-smart-money-monitor-filter.test.ts\` (6 cases): V2 CTF Exchange + V2 NegRisk Exchange + V1 router-legacy paths + EOA/non-matchOrders rejection 都覆盖。

156/156 tests pass, tsc clean。

## 风险与回滚

低风险：仅扩大允许集 (V2 settlement 之前被滤掉，现在被接受)。回滚 = revert 单 commit。

🤖 Generated with [Claude Code](https://claude.com/claude-code)