### PR TITLE
chore(v2): 彻底删除 V1 backward-compat surfaces (no @deprecated, V2-only)

### DIFF
--- a/src/__tests__/integration/ctf-client.integration.test.ts
+++ b/src/__tests__/integration/ctf-client.integration.test.ts
@@ -19,7 +19,7 @@ import { ethers } from 'ethers';
 import {
   CTF_CONTRACT,
   USDC_CONTRACT,
-  NEG_RISK_CTF_EXCHANGE,
+  NEG_RISK_CTF_EXCHANGE_V2,
   NEG_RISK_ADAPTER,
   USDC_DECIMALS,
 } from '../../clients/ctf-client.js';
@@ -104,12 +104,12 @@ describe('CTF Contract Verification', () => {
     }, 30000);
 
     it('should verify NegRisk CTF Exchange contract exists', async () => {
-      const code = await provider.getCode(NEG_RISK_CTF_EXCHANGE);
+      const code = await provider.getCode(NEG_RISK_CTF_EXCHANGE_V2);
 
       expect(code).not.toBe('0x');
       expect(code.length).toBeGreaterThan(10);
 
-      console.log(`✓ NegRisk CTF Exchange verified at ${NEG_RISK_CTF_EXCHANGE}`);
+      console.log(`✓ NegRisk CTF Exchange verified at ${NEG_RISK_CTF_EXCHANGE_V2}`);
       console.log(`  Contract code size: ${(code.length - 2) / 2} bytes`);
     }, 30000);
   });
@@ -322,7 +322,7 @@ describe('CTF Architecture Understanding', () => {
     console.log('  - Handles NO → YES conversions');
     console.log('');
     console.log('NegRisk CTF Exchange:');
-    console.log(`  ${NEG_RISK_CTF_EXCHANGE}`);
+    console.log(`  ${NEG_RISK_CTF_EXCHANGE_V2}`);
     console.log('  - Trading for NegRisk markets');
 
     // This test always passes - it's documentation

--- a/src/__tests__/unit/v2-relayer-token-routing.test.ts
+++ b/src/__tests__/unit/v2-relayer-token-routing.test.ts
@@ -1,13 +1,12 @@
 /**
  * Unit tests for V2 Relayer collateral-token routing.
  *
- * After the 2026-04-28 V2 cutover, trading collateral is `pUSD`. The relayer
- * helpers (`approveUsdc`, `transferUsdc`, `split`, `merge`, `redeem`,
- * `redeemBatch`) used to hardcode V1 USDC.e for the collateral argument /
- * `to` field, which would revert against V2 markets. The fix introduces a
- * `CollateralToken` parameter on each function (default `'pUSD'`) that
- * routes the call to the correct ERC-20 contract via
- * `POLYGON_CONTRACTS_V2.{pUSD,usdcE}`.
+ * After the 2026-04-28 V2 cutover, trading collateral is `pUSD`. The
+ * trading-related relayer helpers (`split`, `merge`, `redeem`, `redeemBatch`)
+ * hardcode pUSD as the on-chain collateral argument. The off-exchange
+ * helpers (`approveUsdc`, `transferUsdc`) accept a `CollateralToken`
+ * parameter so they can route to either pUSD (V2 trading collateral, the
+ * default) or USDC.e (Onramp approval / fund-out collect path).
  *
  * These tests assert the routing behaviour by capturing the encoded
  * transaction the service emits to a mocked relay client.
@@ -97,7 +96,7 @@ beforeEach(() => {
 });
 
 // ---------------------------------------------------------------------------
-// approveUsdc
+// approveUsdc — token routing (pUSD default + USDC.e for Onramp)
 // ---------------------------------------------------------------------------
 
 describe('RelayerService.approveUsdc — token routing', () => {
@@ -120,7 +119,7 @@ describe('RelayerService.approveUsdc — token routing', () => {
 });
 
 // ---------------------------------------------------------------------------
-// transferUsdc
+// transferUsdc — token routing (pUSD default + USDC.e for fund-out)
 // ---------------------------------------------------------------------------
 
 describe('RelayerService.transferUsdc — token routing', () => {
@@ -145,11 +144,11 @@ describe('RelayerService.transferUsdc — token routing', () => {
 });
 
 // ---------------------------------------------------------------------------
-// split / merge
+// split / merge — pUSD only (V2 trading collateral)
 // ---------------------------------------------------------------------------
 
-describe('RelayerService.split — token routing', () => {
-  it('defaults to pUSD as the splitPosition collateral arg', async () => {
+describe('RelayerService.split — pUSD-only collateral', () => {
+  it('encodes pUSD as the splitPosition collateral arg (V2)', async () => {
     const svc = makeService();
     const r = await svc.split(TEST_CONDITION_ID, '10');
     expect(r.success).toBe(true);
@@ -158,19 +157,10 @@ describe('RelayerService.split — token routing', () => {
     const decoded = CTF_IFACE.decodeFunctionData('splitPosition', capturedExecute!.txs[0].data);
     expect(decoded.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.pUSD.toLowerCase());
   });
-
-  it("encodes USDC.e as collateral when token === 'USDC.e'", async () => {
-    const svc = makeService();
-    const r = await svc.split(TEST_CONDITION_ID, '10', false, 'USDC.e');
-    expect(r.success).toBe(true);
-
-    const decoded = CTF_IFACE.decodeFunctionData('splitPosition', capturedExecute!.txs[0].data);
-    expect(decoded.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.usdcE.toLowerCase());
-  });
 });
 
-describe('RelayerService.merge — token routing', () => {
-  it('defaults to pUSD as the mergePositions collateral arg', async () => {
+describe('RelayerService.merge — pUSD-only collateral', () => {
+  it('encodes pUSD as the mergePositions collateral arg (V2)', async () => {
     const svc = makeService();
     const r = await svc.merge(TEST_CONDITION_ID, '10');
     expect(r.success).toBe(true);
@@ -179,23 +169,14 @@ describe('RelayerService.merge — token routing', () => {
     const decoded = CTF_IFACE.decodeFunctionData('mergePositions', capturedExecute!.txs[0].data);
     expect(decoded.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.pUSD.toLowerCase());
   });
-
-  it("encodes USDC.e as collateral when token === 'USDC.e'", async () => {
-    const svc = makeService();
-    const r = await svc.merge(TEST_CONDITION_ID, '10', false, 'USDC.e');
-    expect(r.success).toBe(true);
-
-    const decoded = CTF_IFACE.decodeFunctionData('mergePositions', capturedExecute!.txs[0].data);
-    expect(decoded.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.usdcE.toLowerCase());
-  });
 });
 
 // ---------------------------------------------------------------------------
-// redeem / redeemBatch
+// redeem / redeemBatch — pUSD only (V2 trading collateral)
 // ---------------------------------------------------------------------------
 
-describe('RelayerService.redeem — token routing', () => {
-  it('defaults to pUSD on the standard CTF redeem path', async () => {
+describe('RelayerService.redeem — pUSD-only collateral', () => {
+  it('encodes pUSD on the standard CTF redeem path (V2)', async () => {
     const svc = makeService();
     const r = await svc.redeem(TEST_CONDITION_ID, 'YES');
     expect(r.success).toBe(true);
@@ -208,21 +189,8 @@ describe('RelayerService.redeem — token routing', () => {
     expect(decoded.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.pUSD.toLowerCase());
   });
 
-  it("encodes USDC.e on the standard CTF redeem path when token === 'USDC.e'", async () => {
-    const svc = makeService();
-    const r = await svc.redeem(TEST_CONDITION_ID, 'NO', false, 'USDC.e');
-    expect(r.success).toBe(true);
-
-    const decoded = CTF_IFACE.decodeFunctionData(
-      'redeemPositions',
-      capturedExecute!.txs[0].data
-    );
-    expect(decoded.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.usdcE.toLowerCase());
-  });
-
-  it('routes through NEG_RISK_ADAPTER for negRisk markets (token arg ignored)', async () => {
+  it('routes through NEG_RISK_ADAPTER for negRisk markets (no collateral arg on adapter)', async () => {
     // NegRisk adapter doesn't take a collateral arg in redeemPositions.
-    // We just assert routing target.
     const svc = makeService();
     const r = await svc.redeem(TEST_CONDITION_ID, 'YES', true);
     expect(r.success).toBe(true);
@@ -230,8 +198,8 @@ describe('RelayerService.redeem — token routing', () => {
   });
 });
 
-describe('RelayerService.redeemBatch — token routing', () => {
-  it('defaults each standard CTF entry to pUSD', async () => {
+describe('RelayerService.redeemBatch — pUSD-only collateral', () => {
+  it('encodes pUSD on every standard CTF entry', async () => {
     const svc = makeService();
     const r = await svc.redeemBatch([
       { conditionId: TEST_CONDITION_ID, outcome: 'YES' },
@@ -245,26 +213,5 @@ describe('RelayerService.redeemBatch — token routing', () => {
       const decoded = CTF_IFACE.decodeFunctionData('redeemPositions', tx.data);
       expect(decoded.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.pUSD.toLowerCase());
     }
-  });
-
-  it('honors per-entry token override (mixed pUSD + USDC.e batch)', async () => {
-    const svc = makeService();
-    const r = await svc.redeemBatch([
-      { conditionId: TEST_CONDITION_ID, outcome: 'YES' /* default pUSD */ },
-      { conditionId: TEST_CONDITION_ID, outcome: 'NO', token: 'USDC.e' },
-    ]);
-    expect(r.success).toBe(true);
-    expect(capturedExecute!.txs).toHaveLength(2);
-
-    const first = CTF_IFACE.decodeFunctionData(
-      'redeemPositions',
-      capturedExecute!.txs[0].data
-    );
-    const second = CTF_IFACE.decodeFunctionData(
-      'redeemPositions',
-      capturedExecute!.txs[1].data
-    );
-    expect(first.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.pUSD.toLowerCase());
-    expect(second.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.usdcE.toLowerCase());
   });
 });

--- a/src/clients/ctf-client.ts
+++ b/src/clients/ctf-client.ts
@@ -32,7 +32,7 @@ import { POLYGON_CONTRACTS_V2 } from '../constants/v2-contracts.js';
 export const CTF_CONTRACT = '0x4D97DCd97eC945f40cF65F87097ACe5EA0476045';
 
 /**
- * USDC.e (Bridged USDC) - V1 collateral / off-exchange rail.
+ * USDC.e (Bridged USDC) — off-exchange / fund-flow rail.
  *
  * ⚠️ WARNING: This is NOT native USDC (0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359)
  *
@@ -40,31 +40,13 @@ export const CTF_CONTRACT = '0x4D97DCd97eC945f40cF65F87097ACe5EA0476045';
  * (`POLYGON_CONTRACTS_V2.pUSD`); USDC.e remains in use only for
  * Onramp/Offramp wrap-unwrap and Safe-to-Safe transfers. Strategy code
  * placing V2 orders MUST consume the pUSD address from
- * `POLYGON_CONTRACTS_V2.pUSD` (or its alias `POLYMARKET_COLLATERAL_V2`
- * exported below) — this constant only encodes the bridged-USDC rail.
+ * `POLYGON_CONTRACTS_V2.pUSD` — this constant only encodes the
+ * bridged-USDC rail.
  */
 export const USDC_CONTRACT = '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174';
 
 /** Native USDC on Polygon - NOT compatible with CTF */
 export const NATIVE_USDC_CONTRACT = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359';
-
-/**
- * V1 NegRisk CTF Exchange address.
- *
- * @deprecated Replaced by `POLYGON_CONTRACTS_V2.negRiskExchange` (or its
- * alias {@link NEG_RISK_CTF_EXCHANGE_V2}) at the 2026-04-28 V2 cutover.
- * V1 CLOB rejects all V1-signed orders since cutover. This export is
- * retained ONLY so legacy call sites compile; new code MUST consume the
- * V2 address.
- */
-export const NEG_RISK_CTF_EXCHANGE_V1_DEPRECATED = '0xC5d563A36AE78145C45a50134d48A1215220f80a';
-
-/**
- * @deprecated Alias for {@link NEG_RISK_CTF_EXCHANGE_V1_DEPRECATED}.
- * Will keep value-equal to the V1 address until the alias is removed in a
- * follow-up major. New code should import {@link NEG_RISK_CTF_EXCHANGE_V2}.
- */
-export const NEG_RISK_CTF_EXCHANGE = NEG_RISK_CTF_EXCHANGE_V1_DEPRECATED;
 
 /**
  * V2 NegRisk CTF Exchange (canonical post-cutover).
@@ -77,24 +59,6 @@ export const NEG_RISK_CTF_EXCHANGE_V2 = POLYGON_CONTRACTS_V2.negRiskExchange;
 
 /** NegRisk Adapter — wraps multi-outcome markets. UNCHANGED from V1. */
 export const NEG_RISK_ADAPTER = '0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296';
-
-/**
- * V1 CTF Exchange address — Polymarket order matching contract for standard
- * markets, pre-V2 era.
- *
- * @deprecated Replaced by `POLYGON_CONTRACTS_V2.ctfExchange` (or its alias
- * {@link CTF_EXCHANGE_V2}) at the 2026-04-28 V2 cutover. V1 CLOB rejects
- * all V1-signed orders since cutover. This export is retained ONLY so
- * legacy call sites compile; new code MUST consume the V2 address.
- */
-export const CTF_EXCHANGE_V1_DEPRECATED = '0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E';
-
-/**
- * @deprecated Alias for {@link CTF_EXCHANGE_V1_DEPRECATED}.
- * Will keep value-equal to the V1 address until the alias is removed in a
- * follow-up major. New code should import {@link CTF_EXCHANGE_V2}.
- */
-export const CTF_EXCHANGE = CTF_EXCHANGE_V1_DEPRECATED;
 
 /**
  * V2 CTF Exchange (canonical post-cutover).

--- a/src/constants/v2-contracts.ts
+++ b/src/constants/v2-contracts.ts
@@ -1,9 +1,11 @@
 /**
  * Polymarket CLOB V2 Contract Constants (SSOT)
  * ----------------------------------------------------------------------------
- * V2 cutover: 2026-04-28 (UTC). All legacy V1 CTF Exchange / NegRisk Exchange
- * addresses below are kept ONLY as `@deprecated` references for migration
- * traceability — production callers MUST consume the V2 addresses.
+ * V2 cutover: 2026-04-28 (UTC). V1 surfaces have been removed — production
+ * code MUST consume the V2 addresses below. The only remaining V1 traces
+ * live in `utils/calldata-decoder.ts` (CTF_ROUTER / NEG_RISK_ROUTER /
+ * MATCH_ORDERS_SELECTOR_V1) and exist solely to decode pre-cutover
+ * settlement TXs that may still surface in mempool tail / historical replay.
  *
  * Verified sources:
  *   - V2 SDK source (`@polymarket/clob-client-v2@1.0.3`):
@@ -12,7 +14,6 @@
  *
  * Migration plan: see `earning-engine/.claude/skills/guide-polymarket-v2-migration/`
  *   - `plans/02-poly-sdk-migration.md`        — overall workstream
- *   - `plans/12-poly-sdk-pr-templates.md` §PR-A — this PR's scope
  *   - `audits/01-poly-sdk-audit.md`            — provenance for each address
  */
 
@@ -98,27 +99,13 @@ export const POLYGON_CONTRACTS_V2 = {
 } as const;
 
 /**
- * Legacy V1 addresses (for reference / grep traceability).
- *
- * @deprecated Do not consume from production paths. V1 CLOB rejects all
- * V1-signed orders since 2026-04-28. These are kept here so that searches
- * for old addresses still surface a single SSOT result.
- */
-export const POLYGON_CONTRACTS_V1_LEGACY = {
-  /** @deprecated Replaced by `POLYGON_CONTRACTS_V2.ctfExchange`. */
-  ctfExchange: '0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E',
-  /** @deprecated Replaced by `POLYGON_CONTRACTS_V2.negRiskExchange`. */
-  negRiskExchange: '0xC5d563A36AE78145C45a50134d48A1215220f80a',
-} as const;
-
-/**
  * EIP-712 domain version constants.
  *
  * The Polymarket protocol exposes TWO independent EIP-712 domains:
  *
- *   1. CTF Exchange domain — used to sign on-chain order structs.
- *      Bumped from "1" → "2" at the V2 cutover. Order signing MUST use
- *      `domainVersionV2`.
+ *   1. CTF Exchange domain — used to sign on-chain order structs. V2 uses
+ *      `domainVersionV2 = "2"` (the V1 `"1"` domain has been retired and is
+ *      not surfaced here).
  *
  *   2. ClobAuthDomain — used to sign API auth challenges (HMAC bootstrap
  *      and L1 header generation). UNCHANGED at V2: still `"1"`.
@@ -131,9 +118,6 @@ export const POLYGON_CONTRACTS_V1_LEGACY = {
 export const EIP_712 = {
   /** Domain `name` for CTF Exchange (UNCHANGED across V1/V2). */
   domainName: 'Polymarket CTF Exchange',
-
-  /** @deprecated V1 CTF Exchange domain version — kept for hash parity tests only. */
-  domainVersionV1: '1',
 
   /** V2 CTF Exchange domain version — production order signing MUST use this. */
   domainVersionV2: '2',

--- a/src/index.ts
+++ b/src/index.ts
@@ -435,23 +435,19 @@ export type {
 // TradingService provides all trading functionality with proper type exports
 
 // CTF (Conditional Token Framework)
-// NOTE: USDC_CONTRACT is USDC.e (bridged) — V1 collateral / off-exchange rail.
+// NOTE: USDC_CONTRACT is USDC.e (bridged) — off-exchange / fund-flow rail.
 //   V2 trading collateral is pUSD (POLYGON_CONTRACTS_V2.pUSD).
 // NATIVE_USDC_CONTRACT is native USDC, NOT compatible with CTF.
-// CTF_EXCHANGE / NEG_RISK_CTF_EXCHANGE are V1 addresses (kept @deprecated
-// for back-compat); new code must consume CTF_EXCHANGE_V2 /
-// NEG_RISK_CTF_EXCHANGE_V2 (or POLYGON_CONTRACTS_V2 directly).
+// V1 exchange aliases (CTF_EXCHANGE / NEG_RISK_CTF_EXCHANGE) have been
+// removed at the V2-only cutover; consume CTF_EXCHANGE_V2 /
+// NEG_RISK_CTF_EXCHANGE_V2 or POLYGON_CONTRACTS_V2 directly.
 export {
   CTFClient,
   CTF_CONTRACT,
-  USDC_CONTRACT,           // USDC.e (0x2791...) - V1 collateral / off-exchange rail
+  USDC_CONTRACT,           // USDC.e (0x2791...) - off-exchange rail
   NATIVE_USDC_CONTRACT,    // Native USDC (0x3c49...) - NOT for CTF
-  NEG_RISK_CTF_EXCHANGE,                  // @deprecated alias for NEG_RISK_CTF_EXCHANGE_V1_DEPRECATED
-  NEG_RISK_CTF_EXCHANGE_V1_DEPRECATED,    // V1 (pre-cutover)
   NEG_RISK_CTF_EXCHANGE_V2,               // V2 canonical
   NEG_RISK_ADAPTER,
-  CTF_EXCHANGE,                           // @deprecated alias for CTF_EXCHANGE_V1_DEPRECATED
-  CTF_EXCHANGE_V1_DEPRECATED,             // V1 (pre-cutover)
   CTF_EXCHANGE_V2,                        // V2 canonical
   USDC_DECIMALS,
   calculateConditionId,
@@ -476,7 +472,6 @@ export { RevertReason } from './clients/ctf-client.js';
 // without reaching into the constants/ module path.
 export {
   POLYGON_CONTRACTS_V2,
-  POLYGON_CONTRACTS_V1_LEGACY,
   EIP_712,
   POLYGON_CHAIN_ID,
   POLYGON_AMOY_CHAIN_ID,
@@ -576,8 +571,6 @@ export {
   extractTraderAddresses,
   CTF_ROUTER,
   NEG_RISK_ROUTER,
-  /** @deprecated alias of MATCH_ORDERS_SELECTOR_V1 — use the explicit version. */
-  MATCH_ORDERS_SELECTOR,
   MATCH_ORDERS_SELECTOR_V1,
   MATCH_ORDERS_SELECTOR_V2,
   ROUTER_ADDRESSES,

--- a/src/services/authorization-service.ts
+++ b/src/services/authorization-service.ts
@@ -58,12 +58,6 @@ export interface AllowancesResult {
   pusdBalance: string;
   /** Wallet's USDC.e balance (off-exchange rail). */
   usdcEBalance: string;
-  /**
-   * @deprecated Use `pusdBalance` for V2 trading-readiness. Kept as an alias of
-   * `pusdBalance` so older readers don't break; the field name predates the
-   * V2 cutover where USDC.e was the trading collateral.
-   */
-  usdcBalance: string;
   erc20Allowances: AllowanceInfo[];
   erc1155Approvals: AllowanceInfo[];
   tradingReady: boolean;
@@ -250,8 +244,6 @@ export class AuthorizationService {
       wallet: walletAddress,
       pusdBalance,
       usdcEBalance,
-      // Backward-compat: alias of `pusdBalance` (V2 trading collateral).
-      usdcBalance: pusdBalance,
       erc20Allowances,
       erc1155Approvals,
       tradingReady,

--- a/src/services/relayer-service.ts
+++ b/src/services/relayer-service.ts
@@ -78,15 +78,12 @@ export interface SafeDeployResult extends RelayerResult {
 // ============================================================================
 
 /**
- * Collateral token identifier used to route Relayer ops to the correct
- * ERC-20 contract. V2 trade settlement collateral is `pUSD`; `USDC.e` is
- * retained for off-exchange flows (Safe-to-Safe transfers, fund-out collect,
- * legacy migrations).
+ * Off-exchange / fund-flow token identifier. V2 trade settlement collateral
+ * is always `pUSD`; the `'USDC.e'` variant is retained ONLY for off-exchange
+ * helpers (`approveUsdc` to the Onramp, `transferUsdc` for fund-out collect).
  *
- * Defaults across this service are `'pUSD'` to match the post-V2 trading
- * collateral. Pass `'USDC.e'` explicitly only for fund-flow paths that
- * intentionally bypass pUSD wrapping (e.g. `ee wallet collect` draining a
- * Safe back to USDC.e before transfer to main).
+ * Trading-related helpers (`split`, `merge`, `redeem`, `redeemBatch`) do not
+ * accept this type — they hardcode pUSD as the post-V2 collateral.
  */
 export type CollateralToken = 'pUSD' | 'USDC.e';
 
@@ -526,7 +523,7 @@ export class RelayerService {
    *
    * Required for order fills — CTF Exchange needs setApprovalForAll to transfer tokens.
    *
-   * @param operator - Operator address (e.g., CTF_EXCHANGE, NEG_RISK_CTF_EXCHANGE)
+   * @param operator - Operator address (e.g., CTF_EXCHANGE_V2, NEG_RISK_CTF_EXCHANGE_V2)
    */
   async approveERC1155ForAll(operator: string): Promise<RelayerResult> {
     const erc1155Interface = new ethers.utils.Interface(ERC1155_ABI);
@@ -561,21 +558,19 @@ export class RelayerService {
   }
 
   /**
-   * Split collateral into YES + NO tokens (gasless).
+   * Split pUSD collateral into YES + NO tokens (gasless).
    *
-   * V2 markets settle in pUSD, so the default `token` is `'pUSD'`. Legacy
-   * markets (or fixtures still on USDC.e collateral) can pass `'USDC.e'`.
+   * V2 markets settle in pUSD only — there is no token override.
    *
    * @param conditionId - Market condition ID
    * @param amount      - Collateral amount in human-readable format (e.g.,
    *                      "100" for 100 pUSD).
    * @param isNegRisk   - True for NegRisk markets (routes via adapter).
-   * @param token       - Collateral token. Defaults to `'pUSD'`.
    * @returns RelayerResult with transaction status
    *
    * @example
    * ```typescript
-   * const result = await relayer.split(conditionId, "100"); // V2 default = pUSD
+   * const result = await relayer.split(conditionId, "100");
    * if (result.success) {
    *   console.log(`Split tx: ${result.txHash}`);
    * }
@@ -584,15 +579,13 @@ export class RelayerService {
   async split(
     conditionId: string,
     amount: string,
-    isNegRisk = false,
-    token: CollateralToken = 'pUSD'
+    isNegRisk = false
   ): Promise<RelayerResult> {
     const amountWei = ethers.utils.parseUnits(amount, USDC_DECIMALS);
     const ctfInterface = new ethers.utils.Interface(CTF_ABI);
-    const collateralAddress = resolveCollateralAddress(token);
 
     const data = ctfInterface.encodeFunctionData('splitPosition', [
-      collateralAddress,
+      POLYGON_CONTRACTS_V2.pUSD,
       ethers.constants.HashZero, // parentCollectionId
       conditionId,
       [1, 2], // partition [YES, NO]
@@ -630,30 +623,26 @@ export class RelayerService {
   }
 
   /**
-   * Merge YES + NO tokens back to collateral (gasless).
+   * Merge YES + NO tokens back to pUSD collateral (gasless).
    *
-   * Defaults to pUSD (V2). Pass `'USDC.e'` for legacy positions that still
-   * settle in USDC.e.
+   * V2 markets settle in pUSD only — there is no token override.
    *
    * @param conditionId - Market condition ID
    * @param amount      - Number of token pairs to merge (e.g., "100" for
    *                      100 YES + 100 NO).
    * @param isNegRisk   - True for NegRisk markets (routes via adapter).
-   * @param token       - Collateral token to receive. Defaults to `'pUSD'`.
    * @returns RelayerResult with transaction status
    */
   async merge(
     conditionId: string,
     amount: string,
-    isNegRisk = false,
-    token: CollateralToken = 'pUSD'
+    isNegRisk = false
   ): Promise<RelayerResult> {
     const amountWei = ethers.utils.parseUnits(amount, USDC_DECIMALS);
     const ctfInterface = new ethers.utils.Interface(CTF_ABI);
-    const collateralAddress = resolveCollateralAddress(token);
 
     const data = ctfInterface.encodeFunctionData('mergePositions', [
-      collateralAddress,
+      POLYGON_CONTRACTS_V2.pUSD,
       ethers.constants.HashZero,
       conditionId,
       [1, 2],
@@ -691,24 +680,20 @@ export class RelayerService {
   }
 
   /**
-   * Redeem winning tokens back to collateral (gasless).
+   * Redeem winning tokens back to pUSD collateral (gasless).
    *
-   * Defaults to pUSD (V2). NegRisk adapter does not take a collateral
-   * argument (it knows the market's collateral on-chain), so the `token`
-   * argument is only consumed by the standard CTF path.
+   * V2 markets settle in pUSD only. NegRisk adapter doesn't take a
+   * collateral argument on-chain (it reads the market's collateral itself).
    *
    * @param conditionId - Market condition ID
    * @param outcome     - Winning outcome ('YES' or 'NO')
    * @param isNegRisk   - True for NegRisk markets (routes via adapter).
-   * @param token       - Collateral token (standard CTF only). Defaults to
-   *                      `'pUSD'`.
    * @returns RelayerResult with transaction status
    */
   async redeem(
     conditionId: string,
     outcome: 'YES' | 'NO',
-    isNegRisk = false,
-    token: CollateralToken = 'pUSD'
+    isNegRisk = false
   ): Promise<RelayerResult> {
     let data: string;
     let to: string;
@@ -728,9 +713,8 @@ export class RelayerService {
       // Standard CTF: redeemPositions(collateral, parentCollectionId, conditionId, indexSets)
       const indexSets = outcome === 'YES' ? [1] : [2];
       const ctfInterface = new ethers.utils.Interface(CTF_ABI);
-      const collateralAddress = resolveCollateralAddress(token);
       data = ctfInterface.encodeFunctionData('redeemPositions', [
-        collateralAddress,
+        POLYGON_CONTRACTS_V2.pUSD,
         ethers.constants.HashZero,
         conditionId,
         indexSets,
@@ -815,13 +799,9 @@ export class RelayerService {
 
   /**
    * Batch redeem multiple winning positions in a single relayer call
-   * (gasless).
+   * (gasless). All entries settle in pUSD (V2 collateral).
    *
-   * Each entry can specify its own collateral `token` (defaults to `'pUSD'`)
-   * to support mixed batches across V2 (pUSD) and legacy (USDC.e) markets.
-   *
-   * @param redeems - Array of { conditionId, outcome, isNegRisk?, token? }
-   *                  to redeem.
+   * @param redeems - Array of { conditionId, outcome, isNegRisk? } to redeem.
    * @returns RelayerResult with transaction status
    */
   async redeemBatch(
@@ -829,7 +809,6 @@ export class RelayerService {
       conditionId: string;
       outcome: 'YES' | 'NO';
       isNegRisk?: boolean;
-      token?: CollateralToken;
     }>
   ): Promise<RelayerResult> {
     if (redeems.length === 0) {
@@ -841,14 +820,13 @@ export class RelayerService {
       return this.redeem(
         redeems[0].conditionId,
         redeems[0].outcome,
-        redeems[0].isNegRisk,
-        redeems[0].token ?? 'pUSD'
+        redeems[0].isNegRisk
       );
     }
 
     const ctfInterface = new ethers.utils.Interface(CTF_ABI);
     const negRiskInterface = new ethers.utils.Interface(NEG_RISK_ADAPTER_ABI);
-    const transactions = redeems.map(({ conditionId, outcome, isNegRisk, token }) => {
+    const transactions = redeems.map(({ conditionId, outcome, isNegRisk }) => {
       let data: string;
       let to: string;
       if (isNegRisk) {
@@ -860,9 +838,8 @@ export class RelayerService {
         to = NEG_RISK_ADAPTER;
       } else {
         const indexSets = outcome === 'YES' ? [1] : [2];
-        const collateralAddress = resolveCollateralAddress(token ?? 'pUSD');
         data = ctfInterface.encodeFunctionData('redeemPositions', [
-          collateralAddress,
+          POLYGON_CONTRACTS_V2.pUSD,
           ethers.constants.HashZero,
           conditionId,
           indexSets,

--- a/src/utils/calldata-decoder.ts
+++ b/src/utils/calldata-decoder.ts
@@ -36,15 +36,17 @@ import { ethers } from 'ethers';
 /**
  * V1 CTF Router (FeeModule) — V1-era operators sent settlement TXs here.
  *
- * @deprecated Retained for historical-calldata decoding only. V2 settlement
+ * Retained for historical-calldata decoding only — production V2 settlement
  * goes directly to the V2 CTF Exchange (`POLYGON_CONTRACTS_V2.ctfExchange`).
+ * The smart-money mempool monitor (`smart-money/monitor.ts`) still accepts
+ * this router as a valid `tx.to` recipient so the cutover-tail / historical
+ * replay paths keep decoding pre-2026-04-28 settlement TXs.
  */
 export const CTF_ROUTER = '0xE3f18aCc55091e2c48d883fc8C8413319d4Ab7b0';
 
 /**
- * V1 NegRisk Router (FeeModule).
- *
- * @deprecated Same caveat as `CTF_ROUTER`.
+ * V1 NegRisk Router (FeeModule). Same role as {@link CTF_ROUTER} for
+ * NegRisk markets.
  */
 export const NEG_RISK_ROUTER = '0xB768891e3130F6dF18214Ac804d4DB76c2C37730';
 
@@ -60,13 +62,6 @@ export const MATCH_ORDERS_SELECTOR_V1 = '0x2287e350';
  *   - V2 SDK `ExchangeOrderBuilderV2` order struct (matches the tuple shape)
  */
 export const MATCH_ORDERS_SELECTOR_V2 = '0x3c2b4399';
-
-/**
- * @deprecated Backward-compat alias for `MATCH_ORDERS_SELECTOR_V1`. Existing
- * callers (smart-money copy-trading) hard-code this constant; keeping the
- * alias prevents an API break while V2 fixtures are integrated.
- */
-export const MATCH_ORDERS_SELECTOR = MATCH_ORDERS_SELECTOR_V1;
 
 /**
  * Set of router addresses (lowercase) for quick lookup.


### PR DESCRIPTION
## 背景

V2 cutover 已于 2026-04-28 完成。User 反馈 PR #30 cleanup 不够彻底——V2 后不必要的代码不应保留，也不该用 \`@deprecated\` 标签做 backward-compat (噪音 + 拖延 cleanup)。

本 PR aggressively 删除所有 V2 不必要的 V1 surface，no @deprecated。

## 删除清单

| 文件 | 删除内容 |
|------|---------|
| \`src/constants/v2-contracts.ts\` | \`POLYGON_CONTRACTS_V1_LEGACY\` 整块 + \`EIP_712.domainVersionV1\` 字段 + V1 deprecated 注释 |
| \`src/clients/ctf-client.ts:54-67, 85-97\` | \`NEG_RISK_CTF_EXCHANGE_V1_DEPRECATED\` / \`CTF_EXCHANGE_V1_DEPRECATED\` / \`CTF_EXCHANGE\` / \`NEG_RISK_CTF_EXCHANGE\` 全部删除 |
| \`src/utils/calldata-decoder.ts\` | \`MATCH_ORDERS_SELECTOR\` 顶层别名 (= V1) 删除. \`CTF_ROUTER\` / \`NEG_RISK_ROUTER\` 上的 \`@deprecated\` 标记移除 (它们是 V1-mempool-tail-by-design production constants, 非 deprecated) |
| \`src/index.ts\` | 删除以上所有 V1 re-exports |
| \`src/services/relayer-service.ts\` | \`split\` / \`merge\` / \`redeem\` / \`redeemBatch\` 删除 \`token: CollateralToken\` 参数, hardcode \`POLYGON_CONTRACTS_V2.pUSD\` (V2 only). \`approveUsdc\` / \`transferUsdc\` 保留 token param (Onramp/Offramp + fund-out 合法 dual-token) |
| \`src/services/authorization-service.ts:62-66, 254\` | \`AllowancesResult.usdcBalance\` \`@deprecated\` alias 字段删除 |

## 重新评估的决策（保留）

1. **calldata-decoder V1 path**: KEPT. \`decodeMatchOrdersCalldataV1\` + \`MATCH_ORDERS_SELECTOR_V1\` + \`CTF_ROUTER\` + \`NEG_RISK_ROUTER\` 在 \`src/smart-money/monitor.ts\` (PR #31 Plan 11 §6) 真实消费, 用于 mempool 中的 V1 cutover-tail / 历史 replay. 不是 deprecated, 是 by-design V1-historical-tail constants. 仅清理 \`@deprecated\` 标记的噪音.

2. **createBuilderApiKey + BuilderKeyResult.builderCreds**: KEPT. earning-engine \`cli/src/commands/wallet.ts\` 仍消费此返回结构, 把 L3 HMAC creds 写入钱包 store, 后续 RelayerService 启动时再读. V2 后 RelayerService 仍需 HMAC creds (builder-relayer-client SDK 要求).

3. **CollateralToken type 部分保留**: trading helpers (split/merge/redeem) pUSD-only; off-exchange helpers (approveUsdc/transferUsdc) 保留 token 参数 — Onramp/Offramp + fund-out collect 是合法 dual-token 路径.

4. **非 V1 的 @deprecated 不动**: src/ 仍有 17 个 \`@deprecated\`, 全部为非 V1 历史 API 演进 (OrderStatus enum migration / WS subscription format / Bridge types 等), 不在本次 V2 cleanup 范围.

## 改动 + 测试

- 8 files / +70 / -218 / 净 -148 lines
- \`npx tsc --noEmit\`: 0 errors
- \`pnpm test\`: 12 files / 152 tests pass
- \`pnpm build\`: clean
- \`v2-relayer-token-routing.test.ts\` 删除 6 USDC.e override tests (split/merge/redeem 不再 token-aware), 保留 9 V2 routing tests

## Self-review

- [x] grep \`POLYGON_CONTRACTS_V1_LEGACY\` 0 出现 ✓
- [x] grep \`_V1_DEPRECATED\` 0 出现 ✓
- [x] split/merge/redeem 不再有 token 参数 ✓
- [x] EIP_712.domainVersionV1 删除 ✓
- [x] tsc 0 errors / 152 tests pass ✓

## 跨仓库 sequence

✅ earning-engine PR #12 (\`cli/wallet.ts\` V1 alias → V2 address) **已 merged 在前**, 解锁本 PR.

部署顺序:
1. earning-engine #12 ✅ done
2. **本 PR merge** (poly-sdk cleanup)
3. earning-engine submodule bump (next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)