### PR TITLE
Add presigned order posting APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
   },
   "dependencies": {
     "@catalyst-team/cache": "^0.2.0",
-    "@polymarket/builder-relayer-client": "^0.0.8",
-    "@polymarket/builder-signing-sdk": "^0.0.8",
-    "@polymarket/clob-client-v2": "1.0.3",
+    "@polymarket/builder-relayer-client": "0.0.9",
+    "@polymarket/builder-signing-sdk": "1.0.0",
+    "@polymarket/clob-client-v2": "1.0.6",
     "@types/ws": "^8.18.1",
     "bottleneck": "^2.19.5",
     "ethers": "5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,14 +12,14 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
       '@polymarket/builder-relayer-client':
-        specifier: ^0.0.8
-        version: 0.0.8
+        specifier: 0.0.9
+        version: 0.0.9
       '@polymarket/builder-signing-sdk':
-        specifier: ^0.0.8
-        version: 0.0.8
+        specifier: 1.0.0
+        version: 1.0.0
       '@polymarket/clob-client-v2':
-        specifier: 1.0.3
-        version: 1.0.3(typescript@5.9.3)
+        specifier: 1.0.6
+        version: 1.0.6(typescript@5.9.3)
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -459,14 +459,18 @@ packages:
   '@polymarket/builder-abstract-signer@0.0.1':
     resolution: {integrity: sha512-XuuxQQcXYtqQce8slhqiJQti1lVPr+xXC7M3lbetmNnsc9tlYdYRnojE+tcniCHg7VQ6dokcIu0eLYDtM5vdvQ==}
 
-  '@polymarket/builder-relayer-client@0.0.8':
-    resolution: {integrity: sha512-l9bQvghlMn8FIknw4+QAJ1dA1pyTCHMr0vQff1EKt7aGo8wXKa68FloxKc9PoBF35s7zZ6fsy+hZiRpSaYqvYg==}
+  '@polymarket/builder-relayer-client@0.0.9':
+    resolution: {integrity: sha512-7i5LSSpSFZiNuoLY623krWWEiT/jkxv76tueGTNOVy3ZND+2sJvOJk5+PQFgiws+LNa476UFOodkMEgqH5lSqw==}
 
   '@polymarket/builder-signing-sdk@0.0.8':
     resolution: {integrity: sha512-rZLCFxEdYahl5FiJmhe22RDXysS1ibFJlWz4NT0s3itJRYq3XJzXXHXEZkAQplU+nIS1IlbbKjA4zDQaeCyYtg==}
 
-  '@polymarket/clob-client-v2@1.0.3':
-    resolution: {integrity: sha512-dA2q/IoDh2u0CdEBRSvmbdC/+e+oxbRz1KeuydL3Yv3oGSudG0PAyyK7n/I80n/RV+5ZwreUKjb0pYT1aadVtg==}
+  '@polymarket/builder-signing-sdk@1.0.0':
+    resolution: {integrity: sha512-LNHc8Ox+2ITM6+VIEH5LH3SVh9ScE2mOUAJI789YfyNqhF4n1cNulk35Hb6IZfy1xtNfcEfNotanPLa/U8dCaw==}
+
+  '@polymarket/clob-client-v2@1.0.6':
+    resolution: {integrity: sha512-Y6LefFNuxRs95fLq0m9W9EBjoM2w7EVgtsUGLydjlUFVGBeGhHOa8vll6+C6UZVnQEbdWE6i6hYRCwJE/ZVNKQ==}
+    engines: {node: '>=20.10'}
 
   '@rollup/rollup-android-arm-eabi@4.55.1':
     resolution: {integrity: sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==}
@@ -910,14 +914,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  ox@0.11.3:
-    resolution: {integrity: sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw==}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   ox@0.14.20:
     resolution: {integrity: sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==}
     peerDependencies:
@@ -1028,14 +1024,6 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
-
-  viem@2.44.1:
-    resolution: {integrity: sha512-wfQda7PIJeF9hWiGKV628AfBwyYxyoc89OcgF4s4/chs2PY8ibUA7IG+DWdU4oAkjhHm9w47w1m2dwwOPBU+ng==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   viem@2.48.8:
     resolution: {integrity: sha512-Xj3Nrt66SKtn06kczU91ELn9Difr84ZM5A62BTlaisT5lpgt058i2mBkfMZCXHGb1ocOLjzC2ztPhD0Lvky7uQ==}
@@ -1580,13 +1568,13 @@ snapshots:
       ethers: 5.8.0
       ts-node: 9.1.1(typescript@5.9.3)
       typescript: 5.9.3
-      viem: 2.44.1(typescript@5.9.3)
+      viem: 2.48.8(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - zod
 
-  '@polymarket/builder-relayer-client@0.0.8':
+  '@polymarket/builder-relayer-client@0.0.9':
     dependencies:
       '@polymarket/builder-abstract-signer': 0.0.1
       '@polymarket/builder-signing-sdk': 0.0.8
@@ -1595,7 +1583,7 @@ snapshots:
       ethers: 5.8.0
       tsx: 4.21.0
       typescript: 5.9.3
-      viem: 2.44.1(typescript@5.9.3)
+      viem: 2.48.8(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -1610,7 +1598,13 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@polymarket/clob-client-v2@1.0.3(typescript@5.9.3)':
+  '@polymarket/builder-signing-sdk@1.0.0':
+    dependencies:
+      axios: 1.13.2
+    transitivePeerDependencies:
+      - debug
+
+  '@polymarket/clob-client-v2@1.0.6(typescript@5.9.3)':
     dependencies:
       '@ethersproject/providers': 5.8.0
       '@ethersproject/wallet': 5.8.0
@@ -2091,21 +2085,6 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  ox@0.11.3(typescript@5.9.3):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - zod
-
   ox@0.14.20(typescript@5.9.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -2227,23 +2206,6 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@7.16.0: {}
-
-  viem@2.44.1(typescript@5.9.3):
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)
-      isows: 1.0.7(ws@8.18.3)
-      ox: 0.11.3(typescript@5.9.3)
-      ws: 8.18.3
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
 
   viem@2.48.8(typescript@5.9.3):
     dependencies:

--- a/src/__tests__/unit/trading-service-presign.test.ts
+++ b/src/__tests__/unit/trading-service-presign.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TradingService } from '../../services/trading-service.js';
+import { RateLimiter } from '../../core/rate-limiter.js';
+import { createUnifiedCache } from '../../core/unified-cache.js';
+
+const VALID_PK = '0x' + '1'.repeat(64);
+const VALID_BUILDER_CODE = '0x' + 'c'.repeat(64);
+
+function makeService(fakeClient: Record<string, unknown>) {
+  const service = new TradingService(new RateLimiter(), createUnifiedCache(), {
+    privateKey: VALID_PK,
+    builderCode: VALID_BUILDER_CODE,
+    safeAddress: '0x' + 'a'.repeat(40),
+  });
+  (service as any).initialized = true;
+  (service as any).clobClient = fakeClient;
+  return service;
+}
+
+describe('TradingService presigned orders', () => {
+  it('presignMarketOrder creates a signed payload without posting', async () => {
+    const createMarketOrder = vi.fn(async () => ({ salt: 'signed' }));
+    const postOrder = vi.fn();
+    const service = makeService({ createMarketOrder, postOrder });
+
+    const presigned = await service.presignMarketOrder({
+      tokenId: 'token-1',
+      side: 'BUY',
+      amount: 3,
+      price: 0.5,
+      orderType: 'FAK',
+      tickSize: '0.001',
+      negRisk: false,
+    }, { key: 'key-1', ttlMs: 250 });
+
+    expect(presigned.key).toBe('key-1');
+    expect(presigned.kind).toBe('market');
+    expect(presigned.orderType).toBe('FAK');
+    expect(presigned.fingerprint.walletMode).toBe('builder_safe');
+    expect(presigned.fingerprint.maker).toBe('0x' + 'a'.repeat(40));
+    expect(createMarketOrder).toHaveBeenCalledTimes(1);
+    expect(postOrder).not.toHaveBeenCalled();
+  });
+
+  it('postPresignedOrder posts exactly the provided signed payload once', async () => {
+    const signedOrder = { salt: 'signed' };
+    const postOrder = vi.fn(async () => ({
+      success: true,
+      orderID: 'clob-order-1',
+      status: 'matched',
+    }));
+    const service = makeService({ postOrder });
+
+    const result = await service.postPresignedOrder({
+      key: 'key-1',
+      kind: 'market',
+      orderType: 'FAK',
+      signedOrder: signedOrder as any,
+      fingerprint: {
+        tokenId: 'token-1',
+        side: 'BUY',
+        orderType: 'FAK',
+        amount: 3,
+        walletMode: 'builder_safe',
+        maker: '0x' + 'a'.repeat(40),
+        signer: '0x' + 'b'.repeat(40),
+        signatureType: 2,
+      },
+      createdAt: Date.now(),
+      telemetry: {
+        startedAt: Date.now(),
+        totalMs: 0,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.orderId).toBe('clob-order-1');
+    expect(result.telemetry?.presignHit).toBe(true);
+    expect(result.telemetry?.signAndBuildMs).toBe(0);
+    expect(postOrder).toHaveBeenCalledWith(signedOrder, 'FAK');
+  });
+
+  it('blocks duplicate post of the same presigned object before CLOB', async () => {
+    const postOrder = vi.fn(async () => ({ success: true, orderID: 'clob-order-1' }));
+    const service = makeService({ postOrder });
+    const presigned = {
+      key: 'key-1',
+      kind: 'market' as const,
+      orderType: 'FAK' as const,
+      signedOrder: { salt: 'signed' } as any,
+      fingerprint: {
+        tokenId: 'token-1',
+        side: 'BUY' as const,
+        orderType: 'FAK' as const,
+        amount: 3,
+        walletMode: 'builder_safe',
+        maker: '0x' + 'a'.repeat(40),
+        signer: '0x' + 'b'.repeat(40),
+        signatureType: 2,
+      },
+      createdAt: Date.now(),
+      telemetry: { startedAt: Date.now(), totalMs: 0 },
+    };
+
+    await service.postPresignedOrder(presigned);
+    const second = await service.postPresignedOrder(presigned);
+
+    expect(second.success).toBe(false);
+    expect(second.errorMsg).toMatch(/already been used/);
+    expect(postOrder).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/src/__tests__/unit/trading-service-presign.test.ts
+++ b/src/__tests__/unit/trading-service-presign.test.ts
@@ -109,5 +109,23 @@ describe('TradingService presigned orders', () => {
     expect(second.errorMsg).toMatch(/already been used/);
     expect(postOrder).toHaveBeenCalledTimes(1);
   });
-});
 
+  it('fingerprints deposit-wallet identity with POLY_1271 maker/funder', () => {
+    const depositWallet = '0x' + 'd'.repeat(40);
+    const service = new TradingService(new RateLimiter(), createUnifiedCache(), {
+      privateKey: VALID_PK,
+      builderCode: VALID_BUILDER_CODE,
+      walletMode: 'deposit_wallet',
+      signatureType: 3,
+      funderAddress: depositWallet,
+    });
+
+    const identity = service.getWalletIdentity();
+
+    expect(identity.walletMode).toBe('deposit_wallet');
+    expect(identity.maker).toBe(depositWallet);
+    expect(identity.funder).toBe(depositWallet);
+    expect(identity.signatureType).toBe(3);
+    expect(identity.builderCode).toBe(VALID_BUILDER_CODE);
+  });
+});

--- a/src/__tests__/unit/trading-service-presign.test.ts
+++ b/src/__tests__/unit/trading-service-presign.test.ts
@@ -128,4 +128,14 @@ describe('TradingService presigned orders', () => {
     expect(identity.signatureType).toBe(3);
     expect(identity.builderCode).toBe(VALID_BUILDER_CODE);
   });
+
+  it('rejects deposit-wallet mode without an explicit maker/funder', () => {
+    const service = new TradingService(new RateLimiter(), createUnifiedCache(), {
+      privateKey: VALID_PK,
+      builderCode: VALID_BUILDER_CODE,
+      walletMode: 'deposit_wallet',
+    });
+
+    expect(() => service.getWalletIdentity()).toThrow(/deposit_wallet wallet mode requires funderAddress/);
+  });
 });

--- a/src/__tests__/unit/v2-relayer-token-routing.test.ts
+++ b/src/__tests__/unit/v2-relayer-token-routing.test.ts
@@ -1,9 +1,9 @@
 /**
  * Unit tests for V2 Relayer collateral-token routing.
  *
- * After the 2026-04-28 V2 cutover, trading collateral is `pUSD`. The
- * trading-related relayer helpers (`split`, `merge`, `redeem`, `redeemBatch`)
- * hardcode pUSD as the on-chain collateral argument. The off-exchange
+ * After the 2026-04-28 V2 cutover, CLOB trading balance is `pUSD`, but
+ * standard CTF split/merge/redeem calls still use the underlying `USDC.e`
+ * collateral. The off-exchange
  * helpers (`approveUsdc`, `transferUsdc`) accept a `CollateralToken`
  * parameter so they can route to either pUSD (V2 trading collateral, the
  * default) or USDC.e (Onramp approval / fund-out collect path).
@@ -144,7 +144,7 @@ describe('RelayerService.transferUsdc — token routing', () => {
 });
 
 // ---------------------------------------------------------------------------
-// split / merge — pUSD only (V2 trading collateral)
+// split / merge — CTF collateral routing
 // ---------------------------------------------------------------------------
 
 describe('RelayerService.split — pUSD-only collateral', () => {
@@ -164,16 +164,15 @@ describe('RelayerService.split — pUSD-only collateral', () => {
   });
 });
 
-describe('RelayerService.merge — pUSD-only collateral', () => {
-  it('encodes pUSD as the mergePositions collateral arg (V2)', async () => {
+describe('RelayerService.merge — standard CTF collateral', () => {
+  it('encodes USDC.e as the mergePositions collateral arg (V2 CTF)', async () => {
     const svc = makeService();
     const r = await svc.merge(TEST_CONDITION_ID, '10');
     expect(r.success).toBe(true);
     expect(capturedExecute!.txs[0].to).toBe(CTF_CONTRACT);
 
     const decoded = CTF_IFACE.decodeFunctionData('mergePositions', capturedExecute!.txs[0].data);
-    // See split note above re: pUSD vs USDC.e.
-    expect(decoded.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.pUSD.toLowerCase());
+    expect(decoded.collateralToken.toLowerCase()).toBe(POLYGON_CONTRACTS_V2.usdcE.toLowerCase());
   });
 });
 

--- a/src/core/order-status.test.ts
+++ b/src/core/order-status.test.ts
@@ -1,0 +1,112 @@
+import type { OpenOrder } from '@polymarket/clob-client-v2';
+import { describe, expect, it } from 'vitest';
+import {
+  calculateOrderProgress,
+  canOrderBeCancelled,
+  isActiveStatus,
+  isOrderOpen,
+  isTerminalStatus,
+  isValidStatusTransition,
+  mapApiStatusToInternal,
+  mapInternalStatusToApi,
+} from './order-status.js';
+import { OrderStatus } from './types.js';
+
+function openOrder(status?: string, sizeMatched = '0', originalSize = '10'): OpenOrder {
+  return {
+    status,
+    size_matched: sizeMatched,
+    original_size: originalSize,
+  } as unknown as OpenOrder;
+}
+
+describe('order status mapping', () => {
+  it('maps matched orders by matched quantity', () => {
+    expect(mapApiStatusToInternal(openOrder('matched', '10', '10'))).toBe(OrderStatus.FILLED);
+    expect(mapApiStatusToInternal(openOrder('matched', '11', '10'))).toBe(OrderStatus.FILLED);
+    expect(mapApiStatusToInternal(openOrder('matched', '4', '10'))).toBe(
+      OrderStatus.PARTIALLY_FILLED,
+    );
+    expect(mapApiStatusToInternal(openOrder('matched', '0', '10'))).toBe(OrderStatus.OPEN);
+  });
+
+  it('does not infer full fill when original size is missing or invalid', () => {
+    expect(mapApiStatusToInternal(openOrder('matched', '0', undefined as unknown as string))).toBe(
+      OrderStatus.OPEN,
+    );
+    expect(mapApiStatusToInternal(openOrder('matched', '3', undefined as unknown as string))).toBe(
+      OrderStatus.PARTIALLY_FILLED,
+    );
+    expect(mapApiStatusToInternal(openOrder('live', '3', 'not-a-number'))).toBe(
+      OrderStatus.PARTIALLY_FILLED,
+    );
+    expect(mapApiStatusToInternal(openOrder('unmatched', '3', '0'))).toBe(
+      OrderStatus.PARTIALLY_FILLED,
+    );
+  });
+
+  it('maps live and unmatched as active order leaves', () => {
+    expect(mapApiStatusToInternal(openOrder('LIVE', '0', '10'))).toBe(OrderStatus.OPEN);
+    expect(mapApiStatusToInternal(openOrder('UnMatched', '0', '10'))).toBe(OrderStatus.OPEN);
+    expect(mapApiStatusToInternal(openOrder(undefined, '0', '10'))).toBe(OrderStatus.OPEN);
+  });
+
+  it('uses fill quantity when active-looking API status reports fills', () => {
+    expect(mapApiStatusToInternal(openOrder('live', '3', '10'))).toBe(
+      OrderStatus.PARTIALLY_FILLED,
+    );
+    expect(mapApiStatusToInternal(openOrder('unmatched', '10', '10'))).toBe(
+      OrderStatus.FILLED,
+    );
+  });
+
+  it('maps delayed, cancelled, canceled, expired, and unknown statuses', () => {
+    expect(mapApiStatusToInternal(openOrder('delayed', '0', '10'))).toBe(OrderStatus.PENDING);
+    expect(mapApiStatusToInternal(openOrder('CANCELLED', '0', '10'))).toBe(
+      OrderStatus.CANCELLED,
+    );
+    expect(mapApiStatusToInternal(openOrder('canceled', '0', '10'))).toBe(
+      OrderStatus.CANCELLED,
+    );
+    expect(mapApiStatusToInternal(openOrder('expired', '0', '10'))).toBe(OrderStatus.EXPIRED);
+    expect(mapApiStatusToInternal(openOrder('new-api-status', '0', '10'))).toBe(
+      OrderStatus.OPEN,
+    );
+  });
+
+  it('maps internal statuses back to Polymarket API status strings', () => {
+    expect(mapInternalStatusToApi(OrderStatus.PENDING)).toBe('delayed');
+    expect(mapInternalStatusToApi(OrderStatus.OPEN)).toBe('live');
+    expect(mapInternalStatusToApi(OrderStatus.PARTIALLY_FILLED)).toBe('matched');
+    expect(mapInternalStatusToApi(OrderStatus.FILLED)).toBe('matched');
+    expect(mapInternalStatusToApi(OrderStatus.CANCELLED)).toBe('cancelled');
+    expect(mapInternalStatusToApi(OrderStatus.EXPIRED)).toBe('expired');
+    expect(mapInternalStatusToApi(OrderStatus.REJECTED)).toBe('rejected');
+  });
+});
+
+describe('order status helpers', () => {
+  it('classifies active, open, terminal, and cancelable states', () => {
+    expect(isActiveStatus(OrderStatus.PENDING)).toBe(true);
+    expect(isOrderOpen(OrderStatus.PARTIALLY_FILLED)).toBe(true);
+    expect(canOrderBeCancelled(OrderStatus.PENDING)).toBe(false);
+    expect(canOrderBeCancelled(OrderStatus.PARTIALLY_FILLED)).toBe(true);
+    expect(isTerminalStatus(OrderStatus.FILLED)).toBe(true);
+    expect(isTerminalStatus(OrderStatus.REJECTED)).toBe(true);
+  });
+
+  it('validates lifecycle transitions including partial-fill cancellation', () => {
+    expect(isValidStatusTransition(OrderStatus.PENDING, OrderStatus.OPEN)).toBe(true);
+    expect(isValidStatusTransition(OrderStatus.OPEN, OrderStatus.PARTIALLY_FILLED)).toBe(true);
+    expect(isValidStatusTransition(OrderStatus.PARTIALLY_FILLED, OrderStatus.CANCELLED)).toBe(
+      true,
+    );
+    expect(isValidStatusTransition(OrderStatus.FILLED, OrderStatus.CANCELLED)).toBe(false);
+  });
+
+  it('calculates fill progress defensively', () => {
+    expect(calculateOrderProgress(10, 2.5)).toBe(25);
+    expect(calculateOrderProgress(10, 15)).toBe(100);
+    expect(calculateOrderProgress(0, 15)).toBe(0);
+  });
+});

--- a/src/core/order-status.ts
+++ b/src/core/order-status.ts
@@ -18,6 +18,7 @@ const log = createModuleLogger('order-status');
  *
  * Polymarket CLOB API returns these statuses in OpenOrder.status:
  * - "live"      - Order active in orderbook
+ * - "unmatched" - Order accepted but not matched yet; equivalent to open for tracking
  * - "matched"   - Order has fills (partial or complete)
  * - "delayed"   - Order submitted but not yet active (rare)
  * - "cancelled" - Order cancelled
@@ -32,7 +33,11 @@ const log = createModuleLogger('order-status');
  * 2. "live" with size_matched > 0
  *    Decision: This shouldn't happen (API inconsistency), treat as partially_filled
  *
- * 3. Missing status field
+ * 3. "unmatched" with size_matched > 0
+ *    Decision: Treat by fill quantity. The exchange state is contradictory, but quantity
+ *    is the accounting source of truth for strategy/runtime state.
+ *
+ * 4. Missing status field
  *    Decision: Default to 'open' (most common case)
  */
 
@@ -60,10 +65,11 @@ export function mapApiStatusToInternal(apiOrder: OpenOrder): OrderStatus {
   const apiStatus = apiOrder.status?.toLowerCase() || 'live';
   const originalSize = Number(apiOrder.original_size) || 0;
   const sizeMatched = Number(apiOrder.size_matched) || 0;
+  const hasValidOriginalSize = originalSize > 0;
 
   // Handle "matched" status (could be partial or full)
   if (apiStatus === 'matched') {
-    if (sizeMatched >= originalSize) {
+    if (hasValidOriginalSize && sizeMatched >= originalSize) {
       return OrderStatus.FILLED;
     }
     if (sizeMatched > 0) {
@@ -77,7 +83,19 @@ export function mapApiStatusToInternal(apiOrder: OpenOrder): OrderStatus {
   if (apiStatus === 'live') {
     // Check for fills (shouldn't happen but handle it)
     if (sizeMatched > 0) {
-      return sizeMatched >= originalSize
+      return hasValidOriginalSize && sizeMatched >= originalSize
+        ? OrderStatus.FILLED
+        : OrderStatus.PARTIALLY_FILLED;
+    }
+    return OrderStatus.OPEN;
+  }
+
+  // Handle "unmatched" status. This is still an accepted exchange order from our
+  // runtime's perspective, not a rejection. It remains cancelable unless fills
+  // reported by quantity prove a partial/full match.
+  if (apiStatus === 'unmatched') {
+    if (sizeMatched > 0) {
+      return hasValidOriginalSize && sizeMatched >= originalSize
         ? OrderStatus.FILLED
         : OrderStatus.PARTIALLY_FILLED;
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -48,6 +48,7 @@ export type OrderType = 'GTC' | 'FOK' | 'GTD' | 'FAK';
  *
  * State Mapping (Polymarket API → Internal):
  * - API "live"      → open (order in orderbook, no fills)
+ * - API "unmatched" → open (accepted by CLOB, not matched yet)
  * - API "matched"   → partially_filled (some fills) OR filled (fully filled)
  * - API "delayed"   → pending (order submitted but not yet in orderbook)
  * - API "cancelled" → cancelled
@@ -75,7 +76,7 @@ export enum OrderStatus {
   /**
    * open - Order submitted and active in orderbook, no fills yet
    *
-   * Polymarket API status: "live"
+   * Polymarket API status: "live" or "unmatched"
    * Transitions:
    * - → partially_filled (first fill received)
    * - → filled (immediate full fill, rare)
@@ -89,7 +90,9 @@ export enum OrderStatus {
   /**
    * partially_filled - Order has received some fills but not complete
    *
-   * Polymarket API status: "matched" (size_matched > 0 && size_matched < original_size)
+   * Polymarket API status: "matched" (size_matched > 0 && size_matched < original_size).
+   * If an active-looking status such as "live" or "unmatched" reports size_matched > 0,
+   * local accounting still derives partially_filled from quantity.
    * Transitions:
    * - → filled (remaining size filled)
    * - → cancelled (user cancels remaining)

--- a/src/index.ts
+++ b/src/index.ts
@@ -367,6 +367,10 @@ export type {
   ApiCredentials,
   LimitOrderParams,
   MarketOrderParams,
+  PresignedOrder,
+  PresignedOrderFingerprint,
+  PresignOptions,
+  TradingServiceWalletIdentity,
   ClearPositionParams,
   // Results
   Order,

--- a/src/services/realtime-service-v2.ts
+++ b/src/services/realtime-service-v2.ts
@@ -27,6 +27,13 @@ import { createModuleLogger } from '../core/logger.js';
 
 const log = createModuleLogger('realtime-v2');
 
+function normalizeUserOrderEventType(value: unknown): 'PLACEMENT' | 'UPDATE' | 'CANCELLATION' {
+  const text = String(value ?? '').toUpperCase();
+  if (text === 'PLACEMENT' || text === 'PLACE') return 'PLACEMENT';
+  if (text === 'CANCELLATION' || text === 'CANCEL' || text === 'CANCELLED') return 'CANCELLATION';
+  return 'UPDATE';
+}
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -82,7 +89,13 @@ export interface LastTradeInfo {
 
 export interface PriceChange {
   assetId: string;
-  changes: Array<{ price: string; size: string }>;
+  changes: Array<{
+    price: string;
+    size: string;
+    side?: string;
+    bestBid?: string;
+    bestAsk?: string;
+  }>;
   timestamp: number;
 }
 
@@ -1606,14 +1619,14 @@ export class RealtimeServiceV2 extends EventEmitter {
     if (type === 'order') {
       // order event: Order placed (PLACEMENT), updated (UPDATE), or cancelled (CANCELLATION)
       const order: UserOrder = {
-        orderId: payload.order_id as string || '',
+        orderId: payload.order_id as string || payload.id as string || '',
         market: payload.market as string || '',
-        asset: payload.asset as string || '',
+        asset: payload.asset_id as string || payload.asset as string || '',
         side: payload.side as 'BUY' | 'SELL',
         price: Number(payload.price) || 0,
         originalSize: Number(payload.original_size) || 0,
         sizeMatched: Number(payload.size_matched) || 0,  // API field: size_matched
-        eventType: payload.event_type as 'PLACEMENT' | 'UPDATE' | 'CANCELLATION',
+        eventType: normalizeUserOrderEventType(payload.event_type),
         timestamp,
       };
       this.emit('userOrder', order);
@@ -1777,9 +1790,18 @@ export class RealtimeServiceV2 extends EventEmitter {
   }
 
   private parsePriceChange(payload: Record<string, unknown>, timestamp: number): PriceChange {
-    const changes = payload.price_changes as Array<{ price: string; size: string }> || [];
+    const rawChanges = Array.isArray(payload.price_changes)
+      ? payload.price_changes as Array<Record<string, unknown>>
+      : ('price' in payload && 'size' in payload ? [payload] : []);
+    const changes = rawChanges.map((change) => ({
+      price: String(change.price ?? ''),
+      size: String(change.size ?? ''),
+      side: change.side !== undefined ? String(change.side) : undefined,
+      bestBid: change.best_bid !== undefined ? String(change.best_bid) : undefined,
+      bestAsk: change.best_ask !== undefined ? String(change.best_ask) : undefined,
+    }));
     return {
-      assetId: payload.asset_id as string || '',
+      assetId: payload.asset_id as string || rawChanges.find((c) => c.asset_id)?.asset_id as string || '',
       changes,
       timestamp,
     };

--- a/src/services/relayer-service.ts
+++ b/src/services/relayer-service.ts
@@ -623,9 +623,12 @@ export class RelayerService {
   }
 
   /**
-   * Merge YES + NO tokens back to pUSD collateral (gasless).
+   * Merge YES + NO tokens back to the underlying CTF collateral (gasless).
    *
-   * V2 markets settle in pUSD only — there is no token override.
+   * V2 CLOB trading uses pUSD as the wrapped trading balance, but the
+   * conditional tokens are registered against USDC.e collateral. Using pUSD
+   * here creates a Safe request that the relayer marks failed without an
+   * on-chain tx hash.
    *
    * @param conditionId - Market condition ID
    * @param amount      - Number of token pairs to merge (e.g., "100" for
@@ -642,7 +645,7 @@ export class RelayerService {
     const ctfInterface = new ethers.utils.Interface(CTF_ABI);
 
     const data = ctfInterface.encodeFunctionData('mergePositions', [
-      POLYGON_CONTRACTS_V2.pUSD,
+      POLYGON_CONTRACTS_V2.usdcE,
       ethers.constants.HashZero,
       conditionId,
       [1, 2],

--- a/src/services/relayer-service.ts
+++ b/src/services/relayer-service.ts
@@ -167,7 +167,7 @@ export class RelayerService {
       relayerUrl,
       this.chainId,
       this.wallet,
-      builderConfig
+      builderConfig as any
     );
   }
 

--- a/src/services/trading-service.ts
+++ b/src/services/trading-service.ts
@@ -283,7 +283,7 @@ export interface OrderLatencyTelemetry {
   metadataMs?: number;
   signAndBuildMs?: number;
   postOrderMs?: number;
-  postTransport?: 'sdk_axios' | 'ee_fetch';
+  postTransport?: 'sdk_axios' | 'ee_fetch' | 'ee_https';
   postTimeoutMs?: number;
   postTimedOut?: boolean;
   postErrorCode?: string;
@@ -293,7 +293,7 @@ export interface OrderLatencyTelemetry {
 }
 
 interface ClobPostTelemetry {
-  transport: 'ee_fetch';
+  transport: 'ee_fetch' | 'ee_https';
   startedAt: number;
   endedAt: number;
   latencyMs: number;
@@ -660,27 +660,58 @@ export class TradingService {
     orderType?: string,
   ): Promise<any> {
     const startedAt = Date.now();
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
     const url = new URL(endpoint);
     for (const [key, value] of Object.entries(options.params ?? {})) {
       if (value !== undefined) url.searchParams.set(key, String(value));
     }
+    const payload = JSON.stringify(options.data ?? {});
+    const headers = {
+      'User-Agent': '@polymarket/clob-client',
+      Accept: '*/*',
+      'Content-Type': 'application/json',
+      Connection: 'keep-alive',
+      'Content-Length': Buffer.byteLength(payload).toString(),
+      ...(options.headers ?? {}),
+    };
 
     try {
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-          Connection: 'keep-alive',
-          ...(options.headers ?? {}),
-        },
-        body: JSON.stringify(options.data ?? {}),
-        signal: controller.signal,
+      const { statusCode, body: text } = await new Promise<{ statusCode: number; body: string }>((resolve, reject) => {
+        let timedOut = false;
+        const request = https.request(
+          url,
+          {
+            method: 'POST',
+            headers,
+            agent: https.globalAgent,
+          },
+          (response) => {
+            response.setEncoding('utf8');
+            let body = '';
+            response.on('data', (chunk) => {
+              body += chunk;
+            });
+            response.on('end', () => {
+              resolve({ statusCode: response.statusCode ?? 0, body });
+            });
+          },
+        );
+        const timeout = setTimeout(() => {
+          timedOut = true;
+          const error = new Error(`CLOB immediate order POST timed out after ${timeoutMs}ms`) as Error & { code?: string };
+          error.code = 'ETIMEDOUT';
+          request.destroy(error);
+        }, timeoutMs);
+        request.on('error', (error) => {
+          clearTimeout(timeout);
+          if (timedOut && 'code' in error && !error.code) {
+            (error as Error & { code?: string }).code = 'ETIMEDOUT';
+          }
+          reject(error);
+        });
+        request.on('close', () => clearTimeout(timeout));
+        request.write(payload);
+        request.end();
       });
-      const text = await response.text();
       const endedAt = Date.now();
       let body: any;
       try {
@@ -690,29 +721,27 @@ export class TradingService {
       }
 
       this.lastClobPostTelemetry = {
-        transport: 'ee_fetch',
+        transport: 'ee_https',
         startedAt,
         endedAt,
         latencyMs: endedAt - startedAt,
         timeoutMs,
         timedOut: false,
-        httpStatus: response.status,
+        httpStatus: statusCode,
         orderType,
       };
 
       if (body && typeof body === 'object' && body.status === undefined) {
-        body.status = response.status;
+        body.status = statusCode;
       }
       return body;
     } catch (error) {
       const endedAt = Date.now();
       const errorCode =
-        error instanceof DOMException
-          ? error.name
-          : (error instanceof Error && 'code' in error ? String((error as Error & { code?: string }).code) : undefined);
-      const timedOut = errorCode === 'AbortError';
+        error instanceof Error && 'code' in error ? String((error as Error & { code?: string }).code) : undefined;
+      const timedOut = errorCode === 'ETIMEDOUT';
       this.lastClobPostTelemetry = {
-        transport: 'ee_fetch',
+        transport: 'ee_https',
         startedAt,
         endedAt,
         latencyMs: endedAt - startedAt,
@@ -731,8 +760,6 @@ export class TradingService {
         code: errorCode,
         timeout: timedOut,
       };
-    } finally {
-      clearTimeout(timeout);
     }
   }
 

--- a/src/services/trading-service.ts
+++ b/src/services/trading-service.ts
@@ -27,6 +27,8 @@
  *   for gasless TX envelopes; only the *order signing* path swaps to builderCode.
  */
 
+import * as http from 'node:http';
+import * as https from 'node:https';
 import {
   ClobClient,
   Side as ClobSide,
@@ -63,6 +65,26 @@ export const POLYGON_AMOY = 80002;
 
 // CLOB Host
 const CLOB_HOST = 'https://clob.polymarket.com';
+
+let clobHttpKeepAliveConfigured = false;
+
+function configureClobHttpKeepAlive(logger: Logger): void {
+  if (clobHttpKeepAliveConfigured) return;
+  clobHttpKeepAliveConfigured = true;
+
+  const httpAgent = http.globalAgent as http.Agent & { keepAlive: boolean; keepAliveMsecs: number };
+  const httpsAgent = https.globalAgent as https.Agent & { keepAlive: boolean; keepAliveMsecs: number };
+  httpAgent.keepAlive = true;
+  httpAgent.keepAliveMsecs = 30_000;
+  httpsAgent.keepAlive = true;
+  httpsAgent.keepAliveMsecs = 30_000;
+
+  logger.info('Configured CLOB HTTP keep-alive', {
+    httpKeepAlive: true,
+    httpsKeepAlive: true,
+    keepAliveMsecs: 30_000,
+  });
+}
 
 // ============================================================================
 // Polymarket Order Minimums
@@ -416,6 +438,7 @@ export class TradingService {
     this.chainId = (config.chainId || POLYGON_MAINNET) as Chain;
     this.credentials = config.credentials || null;
     this.dataApi = config.dataApi;
+    configureClobHttpKeepAlive(this.diag);
   }
 
   // ============================================================================

--- a/src/services/trading-service.ts
+++ b/src/services/trading-service.ts
@@ -1426,7 +1426,15 @@ export class TradingService {
         asset_type: assetType as any,
         token_id: tokenId,
       });
-      return { balance: result.balance, allowance: result.allowance };
+      const allowances = result.allowances ?? {};
+      const allowance = Object.values(allowances).reduce((max, value) => {
+        try {
+          return BigInt(value) > BigInt(max) ? value : max;
+        } catch {
+          return max;
+        }
+      }, '0');
+      return { balance: result.balance, allowance };
     });
   }
 

--- a/src/services/trading-service.ts
+++ b/src/services/trading-service.ts
@@ -35,6 +35,7 @@ import {
   OrderType as ClobOrderType,
   Chain,
   SignatureTypeV2,
+  type SignedOrder,
   type OpenOrder,
   type Trade as ClobTrade,
   type TickSize,
@@ -295,6 +296,14 @@ export interface OrderLatencyTelemetry {
   metadataReadyAt?: number;
   signedAt?: number;
   postedAt?: number;
+  presignRequested?: boolean;
+  presignHit?: boolean;
+  presignKey?: string;
+  presignCreatedAt?: number;
+  presignAgeMs?: number;
+  presignBuildMs?: number;
+  presignSignMs?: number;
+  presignFallbackReason?: string;
   preRateMs?: number;
   rateWaitMs?: number;
   metadataMs?: number;
@@ -308,6 +317,50 @@ export interface OrderLatencyTelemetry {
   httpStatus?: number;
   clobStatus?: string;
   success?: boolean;
+}
+
+export interface TradingServiceWalletIdentity {
+  walletMode: 'builder_safe' | 'eoa';
+  maker: string;
+  signer: string;
+  funder?: string;
+  signatureType: number;
+  builderCode?: string;
+}
+
+export interface PresignedOrderFingerprint {
+  tokenId: string;
+  side: Side;
+  orderType: 'GTC' | 'GTD' | 'FOK' | 'FAK';
+  price?: number;
+  size?: number;
+  amount?: number;
+  expiration?: number;
+  tickSize?: TickSize;
+  negRisk?: boolean;
+  walletMode: string;
+  maker: string;
+  signer: string;
+  funder?: string;
+  signatureType: number;
+  builderCode?: string;
+}
+
+export interface PresignedOrder {
+  key: string;
+  kind: 'market' | 'limit';
+  orderType: 'GTC' | 'GTD' | 'FOK' | 'FAK';
+  signedOrder: SignedOrder;
+  fingerprint: PresignedOrderFingerprint;
+  createdAt: number;
+  expiresAt?: number;
+  telemetry: OrderLatencyTelemetry;
+  used?: boolean;
+}
+
+export interface PresignOptions {
+  key?: string;
+  ttlMs?: number;
 }
 
 interface ClobPostTelemetry {
@@ -624,6 +677,52 @@ export class TradingService {
       await this.initialize();
     }
     return this.clobClient!;
+  }
+
+  getWalletIdentity(): TradingServiceWalletIdentity {
+    const builderCode = this.config.builderCode !== undefined
+      ? this.config.builderCode
+      : readBuilderCodeOptional();
+    const isBuilderMode = !!builderCode && !!this.config.safeAddress;
+    const signer = this.wallet.address;
+    return {
+      walletMode: isBuilderMode ? 'builder_safe' : 'eoa',
+      maker: isBuilderMode ? this.config.safeAddress! : signer,
+      signer,
+      funder: isBuilderMode ? this.config.safeAddress : undefined,
+      signatureType: isBuilderMode ? SignatureTypeV2.POLY_GNOSIS_SAFE : SignatureTypeV2.EOA,
+      builderCode,
+    };
+  }
+
+  private createPresignKey(kind: 'market' | 'limit', tokenId: string, orderType: string): string {
+    return `${kind}:${tokenId}:${orderType}:${Date.now()}:${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  private createPresignedFingerprint(
+    params: MarketOrderParams | LimitOrderParams,
+    orderType: 'GTC' | 'GTD' | 'FOK' | 'FAK',
+    wallet: TradingServiceWalletIdentity,
+  ): PresignedOrderFingerprint {
+    const limitParams = params as LimitOrderParams;
+    const marketParams = params as MarketOrderParams;
+    return {
+      tokenId: params.tokenId,
+      side: params.side,
+      orderType,
+      price: params.price,
+      size: 'size' in params ? limitParams.size : undefined,
+      amount: 'amount' in params ? marketParams.amount : undefined,
+      expiration: 'expiration' in params ? limitParams.expiration : undefined,
+      tickSize: params.tickSize,
+      negRisk: params.negRisk,
+      walletMode: wallet.walletMode,
+      maker: wallet.maker,
+      signer: wallet.signer,
+      funder: wallet.funder,
+      signatureType: wallet.signatureType,
+      builderCode: wallet.builderCode,
+    };
   }
 
   private readLastClobPostTelemetry(): ClobPostTelemetry | undefined {
@@ -1034,6 +1133,72 @@ export class TradingService {
     });
   }
 
+  async presignLimitOrder(params: LimitOrderParams, options: PresignOptions = {}): Promise<PresignedOrder> {
+    const startedAt = Date.now();
+    const minOrderSize = params.minimumOrderSize ?? MIN_ORDER_SIZE_SHARES;
+    if (params.size < minOrderSize) {
+      throw new Error(`Order size (${params.size}) is below Polymarket minimum (${minOrderSize} shares)`);
+    }
+
+    const orderValue = params.price * params.size;
+    if (orderValue < MIN_ORDER_VALUE_USDC) {
+      throw new Error(`Order value ($${orderValue.toFixed(2)}) is below Polymarket minimum ($${MIN_ORDER_VALUE_USDC})`);
+    }
+
+    this.ensureBuilderCode();
+    const client = await this.ensureInitialized();
+    this.seedClobClientMarketMetadata(params.tokenId, {
+      tickSize: params.tickSize,
+      negRisk: params.negRisk,
+    });
+    const readyAt = Date.now();
+
+    const [tickSize, negRisk] = await Promise.all([
+      params.tickSize ?? this.getTickSize(params.tokenId),
+      params.negRisk ?? this.isNegRisk(params.tokenId),
+    ]);
+    const metadataReadyAt = Date.now();
+    const orderType = params.orderType === 'GTD' ? ClobOrderType.GTD : ClobOrderType.GTC;
+    const signedOrder = await client.createOrder(
+      {
+        tokenID: params.tokenId,
+        side: params.side === 'BUY' ? ClobSide.BUY : ClobSide.SELL,
+        price: params.price,
+        size: params.size,
+        expiration: params.expiration || 0,
+      },
+      { tickSize, negRisk },
+    );
+    const signedAt = Date.now();
+    const wallet = this.getWalletIdentity();
+    const key = options.key ?? this.createPresignKey('limit', params.tokenId, orderType);
+    return {
+      key,
+      kind: 'limit',
+      orderType,
+      signedOrder,
+      fingerprint: this.createPresignedFingerprint({ ...params, tickSize, negRisk }, orderType, wallet),
+      createdAt: signedAt,
+      expiresAt: options.ttlMs == null ? undefined : signedAt + options.ttlMs,
+      telemetry: {
+        startedAt,
+        readyAt,
+        metadataReadyAt,
+        signedAt,
+        presignRequested: true,
+        presignHit: false,
+        presignKey: key,
+        presignCreatedAt: signedAt,
+        presignBuildMs: signedAt - metadataReadyAt,
+        presignSignMs: signedAt - metadataReadyAt,
+        preRateMs: readyAt - startedAt,
+        metadataMs: metadataReadyAt - readyAt,
+        signAndBuildMs: signedAt - metadataReadyAt,
+        totalMs: signedAt - startedAt,
+      },
+    };
+  }
+
   /**
    * Create and post a market order
    *
@@ -1170,6 +1335,202 @@ export class TradingService {
             startedAt,
             readyAt,
             rateLimiterReadyAt,
+            postOrderMs: postTelemetry?.latencyMs,
+            postTransport: postTelemetry?.transport,
+            postTimeoutMs: postTelemetry?.timeoutMs,
+            postTimedOut: postTelemetry?.timedOut,
+            postErrorCode: postTelemetry?.errorCode,
+            httpStatus: postTelemetry?.httpStatus,
+            totalMs: failedAt - startedAt,
+            success: false,
+          },
+        };
+      }
+    });
+  }
+
+  async presignMarketOrder(params: MarketOrderParams, options: PresignOptions = {}): Promise<PresignedOrder> {
+    const startedAt = Date.now();
+    if (params.amount < MIN_ORDER_VALUE_USDC) {
+      throw new Error(`Order amount ($${params.amount.toFixed(2)}) is below Polymarket minimum ($${MIN_ORDER_VALUE_USDC})`);
+    }
+
+    this.ensureBuilderCode();
+    const client = await this.ensureInitialized();
+    this.seedClobClientMarketMetadata(params.tokenId, {
+      tickSize: params.tickSize,
+      negRisk: params.negRisk,
+    });
+    const readyAt = Date.now();
+
+    const [tickSize, negRisk] = await Promise.all([
+      params.tickSize ?? this.getTickSize(params.tokenId),
+      params.negRisk ?? this.isNegRisk(params.tokenId),
+    ]);
+    const metadataReadyAt = Date.now();
+    const orderType = params.orderType === 'FAK' ? ClobOrderType.FAK : ClobOrderType.FOK;
+    const signedOrder = await client.createMarketOrder(
+      {
+        tokenID: params.tokenId,
+        side: params.side === 'BUY' ? ClobSide.BUY : ClobSide.SELL,
+        amount: params.amount,
+        price: params.price,
+      },
+      { tickSize, negRisk },
+    );
+    const signedAt = Date.now();
+    const wallet = this.getWalletIdentity();
+    const key = options.key ?? this.createPresignKey('market', params.tokenId, orderType);
+    return {
+      key,
+      kind: 'market',
+      orderType,
+      signedOrder,
+      fingerprint: this.createPresignedFingerprint({ ...params, tickSize, negRisk }, orderType, wallet),
+      createdAt: signedAt,
+      expiresAt: options.ttlMs == null ? undefined : signedAt + options.ttlMs,
+      telemetry: {
+        startedAt,
+        readyAt,
+        metadataReadyAt,
+        signedAt,
+        presignRequested: true,
+        presignHit: false,
+        presignKey: key,
+        presignCreatedAt: signedAt,
+        presignBuildMs: signedAt - metadataReadyAt,
+        presignSignMs: signedAt - metadataReadyAt,
+        preRateMs: readyAt - startedAt,
+        metadataMs: metadataReadyAt - readyAt,
+        signAndBuildMs: signedAt - metadataReadyAt,
+        totalMs: signedAt - startedAt,
+      },
+    };
+  }
+
+  async postPresignedOrder(presigned: PresignedOrder): Promise<OrderResult> {
+    const startedAt = Date.now();
+    if (presigned.used) {
+      return {
+        success: false,
+        errorMsg: `Presigned order ${presigned.key} has already been used`,
+        telemetry: {
+          startedAt,
+          presignRequested: true,
+          presignHit: false,
+          presignKey: presigned.key,
+          presignCreatedAt: presigned.createdAt,
+          presignAgeMs: startedAt - presigned.createdAt,
+          presignFallbackReason: 'already_used',
+          totalMs: 0,
+          success: false,
+        },
+      };
+    }
+    if (presigned.expiresAt != null && presigned.expiresAt <= startedAt) {
+      return {
+        success: false,
+        errorMsg: `Presigned order ${presigned.key} expired`,
+        telemetry: {
+          startedAt,
+          presignRequested: true,
+          presignHit: false,
+          presignKey: presigned.key,
+          presignCreatedAt: presigned.createdAt,
+          presignAgeMs: startedAt - presigned.createdAt,
+          presignFallbackReason: 'expired',
+          totalMs: 0,
+          success: false,
+        },
+      };
+    }
+
+    this.ensureBuilderCode();
+    const client = await this.ensureInitialized();
+    const readyAt = Date.now();
+    return this.rateLimiter.execute(ApiType.CLOB_API, async () => {
+      const rateLimiterReadyAt = Date.now();
+      try {
+        this.lastClobPostTelemetry = undefined;
+        presigned.used = true;
+        const result = await client.postOrder(presigned.signedOrder, presigned.orderType as ClobOrderType);
+        const postedAt = Date.now();
+        const postTelemetry = this.readLastClobPostTelemetry();
+        const telemetry: OrderLatencyTelemetry = {
+          startedAt,
+          readyAt,
+          rateLimiterReadyAt,
+          postedAt,
+          presignRequested: true,
+          presignHit: true,
+          presignKey: presigned.key,
+          presignCreatedAt: presigned.createdAt,
+          presignAgeMs: startedAt - presigned.createdAt,
+          presignBuildMs: presigned.telemetry.presignBuildMs ?? presigned.telemetry.signAndBuildMs,
+          presignSignMs: presigned.telemetry.presignSignMs,
+          preRateMs: readyAt - startedAt,
+          rateWaitMs: rateLimiterReadyAt - readyAt,
+          signAndBuildMs: 0,
+          postOrderMs: postedAt - rateLimiterReadyAt,
+          postTransport: postTelemetry?.transport ?? 'sdk_axios',
+          postTimeoutMs: postTelemetry?.timeoutMs,
+          postTimedOut: postTelemetry?.timedOut,
+          postErrorCode: postTelemetry?.errorCode,
+          totalMs: postedAt - startedAt,
+          httpStatus: postTelemetry?.httpStatus,
+          clobStatus: result.status,
+          success: result.success === true,
+        };
+        if (presigned.kind === 'market') {
+          const success = result.success === true;
+          const postTimedOut = telemetry.postTimedOut === true || result.timeout === true;
+          const unknown = postTimedOut;
+          const errorMsg = unknown
+            ? (result.errorMsg || `CLOB immediate order POST outcome unknown after ${telemetry.postTimeoutMs ?? 'configured'}ms`)
+            : (!success
+              ? (result.errorMsg || `Market order ${presigned.orderType === 'FOK' ? 'FOK not filled' : 'FAK killed/no-fill'} (status: ${result.status ?? 'unknown'}, orderID: ${result.orderID ?? 'none'})`)
+              : result.errorMsg);
+          return {
+            success,
+            orderId: result.orderID,
+            orderIds: result.orderIDs,
+            errorMsg,
+            transactionHashes: result.transactionsHashes,
+            telemetry,
+            unknown,
+            postTimedOut,
+          };
+        }
+        const success = result.success === true ||
+          (result.success !== false && result.orderID !== undefined && result.orderID !== '');
+        return {
+          success,
+          orderId: result.orderID,
+          orderIds: result.orderIDs,
+          errorMsg: !success
+            ? (result.errorMsg || `Limit order rejected (status: ${result.status ?? 'unknown'}, response: ${JSON.stringify(result)})`)
+            : result.errorMsg,
+          transactionHashes: result.transactionsHashes,
+          telemetry,
+        };
+      } catch (error) {
+        const failedAt = Date.now();
+        const postTelemetry = this.readLastClobPostTelemetry();
+        const postTimedOut = postTelemetry?.timedOut === true;
+        return {
+          success: false,
+          errorMsg: `Presigned order POST failed: ${error instanceof Error ? error.message : String(error)}`,
+          unknown: postTimedOut,
+          postTimedOut,
+          telemetry: {
+            startedAt,
+            readyAt,
+            rateLimiterReadyAt,
+            presignRequested: true,
+            presignHit: true,
+            presignKey: presigned.key,
+            presignCreatedAt: presigned.createdAt,
+            presignAgeMs: startedAt - presigned.createdAt,
             postOrderMs: postTelemetry?.latencyMs,
             postTransport: postTelemetry?.transport,
             postTimeoutMs: postTelemetry?.timeoutMs,

--- a/src/services/trading-service.ts
+++ b/src/services/trading-service.ts
@@ -306,6 +306,7 @@ export interface OrderLatencyTelemetry {
   postErrorCode?: string;
   totalMs: number;
   httpStatus?: number;
+  clobStatus?: string;
   success?: boolean;
 }
 
@@ -1104,7 +1105,8 @@ export class TradingService {
           postTimedOut: postTelemetry?.timedOut,
           postErrorCode: postTelemetry?.errorCode,
           totalMs: postedAt - startedAt,
-          httpStatus: result.status ?? postTelemetry?.httpStatus,
+          httpStatus: postTelemetry?.httpStatus,
+          clobStatus: result.status,
           success: result.success === true,
         };
 
@@ -1125,7 +1127,7 @@ export class TradingService {
           postErrorCode: telemetry.postErrorCode,
           totalMs: telemetry.totalMs,
           success: result.success === true,
-          status: telemetry.httpStatus,
+          status: telemetry.clobStatus ?? telemetry.httpStatus,
           orderId: result.orderID ? result.orderID.slice(0, 12) : undefined,
         });
 

--- a/src/services/trading-service.ts
+++ b/src/services/trading-service.ts
@@ -214,6 +214,14 @@ export interface PrepareMarketMetadataResult {
   errorMsg?: string;
 }
 
+export interface MarketFeeInfo {
+  /** CLOB market fee rate, e.g. 0.07 for crypto markets. */
+  rate: number;
+  /** Fee curve exponent from CLOB market info; current V2 markets use 1. */
+  exponent: number;
+  source: 'clob_market_info';
+}
+
 /** Parameters for clearing a token position (market sell) */
 export interface ClearPositionParams {
   tokenId: string;
@@ -863,6 +871,41 @@ export class TradingService {
       this.diag.warn('TradingService market metadata prepare failed', result);
       return result;
     }
+  }
+
+  /**
+   * Return the official per-market fee parameters cached by CLOB market info.
+   *
+   * Polymarket applies taker fees at match time. USER channel trade events can
+   * omit or zero `fee_rate_bps`, so latency-sensitive callers should preload
+   * CLOB market info once and use `fd.r/fd.e` for realtime wallet accounting,
+   * then reconcile against Data API / chain deltas after the run.
+   */
+  async getMarketFeeInfo(tokenId: string, conditionId?: string): Promise<MarketFeeInfo> {
+    const client = await this.ensureInitialized();
+    const rawClient = client as unknown as {
+      tokenConditionMap?: Record<string, string>;
+      feeInfos?: Record<string, { rate?: number; exponent?: number }>;
+      getClobMarketInfo?: (conditionId: string) => Promise<unknown>;
+    };
+
+    rawClient.tokenConditionMap ??= {};
+    if (conditionId) rawClient.tokenConditionMap[tokenId] = conditionId;
+
+    if (!rawClient.feeInfos?.[tokenId] && conditionId && rawClient.getClobMarketInfo) {
+      await rawClient.getClobMarketInfo(conditionId);
+    }
+
+    const info = rawClient.feeInfos?.[tokenId];
+    if (info?.rate != null && info?.exponent != null) {
+      return {
+        rate: Number(info.rate),
+        exponent: Number(info.exponent),
+        source: 'clob_market_info',
+      };
+    }
+
+    throw new Error(`failed to load market fee info for token ${tokenId}`);
   }
 
   // ============================================================================

--- a/src/services/trading-service.ts
+++ b/src/services/trading-service.ts
@@ -268,6 +268,24 @@ export interface OrderResult {
   orderIds?: string[];
   errorMsg?: string;
   transactionHashes?: string[];
+  telemetry?: OrderLatencyTelemetry;
+}
+
+export interface OrderLatencyTelemetry {
+  startedAt: number;
+  readyAt?: number;
+  rateLimiterReadyAt?: number;
+  metadataReadyAt?: number;
+  signedAt?: number;
+  postedAt?: number;
+  preRateMs?: number;
+  rateWaitMs?: number;
+  metadataMs?: number;
+  signAndBuildMs?: number;
+  postOrderMs?: number;
+  totalMs: number;
+  httpStatus?: number;
+  success?: boolean;
 }
 
 export interface TradeInfo {
@@ -842,6 +860,22 @@ export class TradingService {
         const signedAt = Date.now();
         const result = await client.postOrder(signedOrder, orderType);
         const postedAt = Date.now();
+        const telemetry: OrderLatencyTelemetry = {
+          startedAt,
+          readyAt,
+          rateLimiterReadyAt,
+          metadataReadyAt,
+          signedAt,
+          postedAt,
+          preRateMs: readyAt - startedAt,
+          rateWaitMs: rateLimiterReadyAt - readyAt,
+          metadataMs: metadataReadyAt - rateLimiterReadyAt,
+          signAndBuildMs: signedAt - metadataReadyAt,
+          postOrderMs: postedAt - signedAt,
+          totalMs: postedAt - startedAt,
+          httpStatus: result.status,
+          success: result.success === true,
+        };
 
         this.diag.info('TradingService market order latency', {
           tokenId: params.tokenId.slice(0, 12),
@@ -849,12 +883,12 @@ export class TradingService {
           orderType: params.orderType ?? 'FOK',
           amount: params.amount,
           price: params.price,
-          preRateMs: readyAt - startedAt,
-          rateWaitMs: rateLimiterReadyAt - readyAt,
-          metadataMs: metadataReadyAt - rateLimiterReadyAt,
-          signAndBuildMs: signedAt - metadataReadyAt,
-          postOrderMs: postedAt - signedAt,
-          totalMs: postedAt - startedAt,
+          preRateMs: telemetry.preRateMs,
+          rateWaitMs: telemetry.rateWaitMs,
+          metadataMs: telemetry.metadataMs,
+          signAndBuildMs: telemetry.signAndBuildMs,
+          postOrderMs: telemetry.postOrderMs,
+          totalMs: telemetry.totalMs,
           success: result.success === true,
           status: result.status,
           orderId: result.orderID ? result.orderID.slice(0, 12) : undefined,
@@ -878,11 +912,20 @@ export class TradingService {
           orderIds: result.orderIDs,
           errorMsg,
           transactionHashes: result.transactionsHashes,
+          telemetry,
         };
       } catch (error) {
+        const failedAt = Date.now();
         return {
           success: false,
           errorMsg: `Market order failed: ${error instanceof Error ? error.message : String(error)}`,
+          telemetry: {
+            startedAt,
+            readyAt,
+            rateLimiterReadyAt,
+            totalMs: failedAt - startedAt,
+            success: false,
+          },
         };
       }
     });

--- a/src/services/trading-service.ts
+++ b/src/services/trading-service.ts
@@ -283,9 +283,25 @@ export interface OrderLatencyTelemetry {
   metadataMs?: number;
   signAndBuildMs?: number;
   postOrderMs?: number;
+  postTransport?: 'sdk_axios' | 'ee_fetch';
+  postTimeoutMs?: number;
+  postTimedOut?: boolean;
+  postErrorCode?: string;
   totalMs: number;
   httpStatus?: number;
   success?: boolean;
+}
+
+interface ClobPostTelemetry {
+  transport: 'ee_fetch';
+  startedAt: number;
+  endedAt: number;
+  latencyMs: number;
+  timeoutMs: number;
+  timedOut: boolean;
+  httpStatus?: number;
+  errorCode?: string;
+  orderType?: string;
 }
 
 export interface TradeInfo {
@@ -434,6 +450,7 @@ export class TradingService {
   private initialized = false;
   private tickSizeCache: Map<string, string> = new Map();
   private negRiskCache: Map<string, boolean> = new Map();
+  private lastClobPostTelemetry: ClobPostTelemetry | undefined;
 
   private dataApi: DataApiClient | undefined;
 
@@ -522,6 +539,7 @@ export class TradingService {
       funderAddress: isBuilderMode ? this.config.safeAddress : undefined,
       builderConfig,
     });
+    this.installClobFastPost(this.clobClient);
 
     // PR-1: builderCode boot echo (fires once per TradingService init).
     this.diag.info('TradingService V2 initialized', {
@@ -588,6 +606,134 @@ export class TradingService {
       await this.initialize();
     }
     return this.clobClient!;
+  }
+
+  private readLastClobPostTelemetry(): ClobPostTelemetry | undefined {
+    return this.lastClobPostTelemetry;
+  }
+
+  private getImmediatePostTimeoutMs(): number {
+    const raw = process.env.POLY_CLOB_IMMEDIATE_POST_TIMEOUT_MS ?? '1500';
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed <= 0) return 1500;
+    return Math.max(250, Math.min(10_000, Math.floor(parsed)));
+  }
+
+  private installClobFastPost(client: ClobClient): void {
+    const patchedClient = client as unknown as {
+      post?: (endpoint: string, options?: { headers?: Record<string, string>; data?: unknown; params?: Record<string, unknown> }, ipAddressHeaderRequired?: boolean) => Promise<unknown>;
+      __eeFastPostInstalled?: boolean;
+    };
+
+    if (patchedClient.__eeFastPostInstalled || typeof patchedClient.post !== 'function') return;
+
+    const originalPost = patchedClient.post.bind(patchedClient);
+    patchedClient.post = async (endpoint, options = {}, ipAddressHeaderRequired) => {
+      const data = options.data as { orderType?: string } | undefined;
+      const orderType = data?.orderType;
+      const isImmediateOrder =
+        endpoint.includes('/order') &&
+        (orderType === ClobOrderType.FAK || orderType === ClobOrderType.FOK);
+
+      if (!isImmediateOrder) {
+        return originalPost(endpoint, options, ipAddressHeaderRequired);
+      }
+
+      return this.postClobWithFetch(
+        endpoint,
+        {
+          headers: options.headers,
+          data: options.data,
+          params: options.params,
+        },
+        this.getImmediatePostTimeoutMs(),
+        orderType,
+      );
+    };
+    patchedClient.__eeFastPostInstalled = true;
+  }
+
+  private async postClobWithFetch(
+    endpoint: string,
+    options: { headers?: Record<string, string>; data?: unknown; params?: Record<string, unknown> },
+    timeoutMs: number,
+    orderType?: string,
+  ): Promise<any> {
+    const startedAt = Date.now();
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    const url = new URL(endpoint);
+    for (const [key, value] of Object.entries(options.params ?? {})) {
+      if (value !== undefined) url.searchParams.set(key, String(value));
+    }
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          Connection: 'keep-alive',
+          ...(options.headers ?? {}),
+        },
+        body: JSON.stringify(options.data ?? {}),
+        signal: controller.signal,
+      });
+      const text = await response.text();
+      const endedAt = Date.now();
+      let body: any;
+      try {
+        body = text ? JSON.parse(text) : {};
+      } catch {
+        body = { error: text };
+      }
+
+      this.lastClobPostTelemetry = {
+        transport: 'ee_fetch',
+        startedAt,
+        endedAt,
+        latencyMs: endedAt - startedAt,
+        timeoutMs,
+        timedOut: false,
+        httpStatus: response.status,
+        orderType,
+      };
+
+      if (body && typeof body === 'object' && body.status === undefined) {
+        body.status = response.status;
+      }
+      return body;
+    } catch (error) {
+      const endedAt = Date.now();
+      const errorCode =
+        error instanceof DOMException
+          ? error.name
+          : (error instanceof Error && 'code' in error ? String((error as Error & { code?: string }).code) : undefined);
+      const timedOut = errorCode === 'AbortError';
+      this.lastClobPostTelemetry = {
+        transport: 'ee_fetch',
+        startedAt,
+        endedAt,
+        latencyMs: endedAt - startedAt,
+        timeoutMs,
+        timedOut,
+        httpStatus: 0,
+        errorCode,
+        orderType,
+      };
+      return {
+        success: false,
+        status: 0,
+        errorMsg: timedOut
+          ? `CLOB immediate order POST timed out after ${timeoutMs}ms`
+          : `CLOB immediate order POST failed: ${error instanceof Error ? error.message : String(error)}`,
+        code: errorCode,
+        timeout: timedOut,
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 
   private seedClobClientMarketMetadata(
@@ -858,8 +1004,10 @@ export class TradingService {
           { tickSize, negRisk },
         );
         const signedAt = Date.now();
+        this.lastClobPostTelemetry = undefined;
         const result = await client.postOrder(signedOrder, orderType);
         const postedAt = Date.now();
+        const postTelemetry = this.readLastClobPostTelemetry();
         const telemetry: OrderLatencyTelemetry = {
           startedAt,
           readyAt,
@@ -872,8 +1020,12 @@ export class TradingService {
           metadataMs: metadataReadyAt - rateLimiterReadyAt,
           signAndBuildMs: signedAt - metadataReadyAt,
           postOrderMs: postedAt - signedAt,
+          postTransport: postTelemetry?.transport ?? 'sdk_axios',
+          postTimeoutMs: postTelemetry?.timeoutMs,
+          postTimedOut: postTelemetry?.timedOut,
+          postErrorCode: postTelemetry?.errorCode,
           totalMs: postedAt - startedAt,
-          httpStatus: result.status,
+          httpStatus: result.status ?? postTelemetry?.httpStatus,
           success: result.success === true,
         };
 
@@ -888,9 +1040,13 @@ export class TradingService {
           metadataMs: telemetry.metadataMs,
           signAndBuildMs: telemetry.signAndBuildMs,
           postOrderMs: telemetry.postOrderMs,
+          postTransport: telemetry.postTransport,
+          postTimeoutMs: telemetry.postTimeoutMs,
+          postTimedOut: telemetry.postTimedOut,
+          postErrorCode: telemetry.postErrorCode,
           totalMs: telemetry.totalMs,
           success: result.success === true,
-          status: result.status,
+          status: telemetry.httpStatus,
           orderId: result.orderID ? result.orderID.slice(0, 12) : undefined,
         });
 
@@ -916,6 +1072,7 @@ export class TradingService {
         };
       } catch (error) {
         const failedAt = Date.now();
+        const postTelemetry = this.readLastClobPostTelemetry();
         return {
           success: false,
           errorMsg: `Market order failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -923,6 +1080,12 @@ export class TradingService {
             startedAt,
             readyAt,
             rateLimiterReadyAt,
+            postOrderMs: postTelemetry?.latencyMs,
+            postTransport: postTelemetry?.transport,
+            postTimeoutMs: postTelemetry?.timeoutMs,
+            postTimedOut: postTelemetry?.timedOut,
+            postErrorCode: postTelemetry?.errorCode,
+            httpStatus: postTelemetry?.httpStatus,
             totalMs: failedAt - startedAt,
             success: false,
           },

--- a/src/services/trading-service.ts
+++ b/src/services/trading-service.ts
@@ -269,6 +269,15 @@ export interface OrderResult {
   errorMsg?: string;
   transactionHashes?: string[];
   telemetry?: OrderLatencyTelemetry;
+  /**
+   * True when the order POST reached an indeterminate transport state.
+   *
+   * This is not a business reject. CLOB may still accept and match the signed
+   * order after the local HTTP request times out, so callers must reconcile via
+   * USER WS / Data API / positions before retrying the same intent.
+   */
+  unknown?: boolean;
+  postTimedOut?: boolean;
 }
 
 export interface OrderLatencyTelemetry {
@@ -613,9 +622,9 @@ export class TradingService {
   }
 
   private getImmediatePostTimeoutMs(): number {
-    const raw = process.env.POLY_CLOB_IMMEDIATE_POST_TIMEOUT_MS ?? '1500';
+    const raw = process.env.POLY_CLOB_IMMEDIATE_POST_TIMEOUT_MS ?? '3000';
     const parsed = Number(raw);
-    if (!Number.isFinite(parsed) || parsed <= 0) return 1500;
+    if (!Number.isFinite(parsed) || parsed <= 0) return 3000;
     return Math.max(250, Math.min(10_000, Math.floor(parsed)));
   }
 
@@ -1085,9 +1094,13 @@ export class TradingService {
         const isFokOrder = params.orderType !== 'FAK'; // default is FOK
         const success = result.success === true;
 
-        const errorMsg = !success
-          ? (result.errorMsg || `Market order ${isFokOrder ? 'FOK not filled' : 'FAK killed/no-fill'} (status: ${result.status ?? 'unknown'}, orderID: ${result.orderID ?? 'none'})`)
-          : result.errorMsg;
+        const postTimedOut = telemetry.postTimedOut === true || result.timeout === true;
+        const unknown = postTimedOut;
+        const errorMsg = unknown
+          ? (result.errorMsg || `CLOB immediate order POST outcome unknown after ${telemetry.postTimeoutMs ?? 'configured'}ms`)
+          : (!success
+            ? (result.errorMsg || `Market order ${isFokOrder ? 'FOK not filled' : 'FAK killed/no-fill'} (status: ${result.status ?? 'unknown'}, orderID: ${result.orderID ?? 'none'})`)
+            : result.errorMsg);
 
         return {
           success,
@@ -1096,13 +1109,18 @@ export class TradingService {
           errorMsg,
           transactionHashes: result.transactionsHashes,
           telemetry,
+          unknown,
+          postTimedOut,
         };
       } catch (error) {
         const failedAt = Date.now();
         const postTelemetry = this.readLastClobPostTelemetry();
+        const postTimedOut = postTelemetry?.timedOut === true;
         return {
           success: false,
           errorMsg: `Market order failed: ${error instanceof Error ? error.message : String(error)}`,
+          unknown: postTimedOut,
+          postTimedOut,
           telemetry: {
             startedAt,
             readyAt,

--- a/src/services/trading-service.ts
+++ b/src/services/trading-service.ts
@@ -172,6 +172,26 @@ export interface MarketOrderParams {
   negRisk?: boolean;
 }
 
+export interface PrepareMarketMetadataParams {
+  conditionId: string;
+  tokenIds: string[];
+  /** Optional hot-path metadata from WS/orderbook cache. */
+  tickSize?: TickSize;
+  /** Optional market-level negRisk flag. */
+  negRisk?: boolean;
+}
+
+export interface PrepareMarketMetadataResult {
+  success: boolean;
+  conditionId: string;
+  tokenCount: number;
+  latencyMs: number;
+  marketInfoMs?: number;
+  builderFeeMs?: number;
+  versionMs?: number;
+  errorMsg?: string;
+}
+
 /** Parameters for clearing a token position (market sell) */
 export interface ClearPositionParams {
   tokenId: string;
@@ -550,6 +570,78 @@ export class TradingService {
     }
   }
 
+  /**
+   * Preload the CLOB client's per-market caches before a latency-sensitive
+   * strategy can emit its first order. The official client always calls
+   * `_ensureMarketInfoCached(tokenID)` and, for builder orders,
+   * `ensureBuilderFeeRateCached(builderCode)` while creating an order. If those
+   * REST calls happen inside the edge window, FAK/FOK orders can miss by seconds.
+   */
+  async prepareMarketMetadata(params: PrepareMarketMetadataParams): Promise<PrepareMarketMetadataResult> {
+    const startedAt = Date.now();
+    try {
+      const client = await this.ensureInitialized();
+      const rawClient = client as unknown as {
+        tokenConditionMap?: Record<string, string>;
+        getClobMarketInfo?: (conditionId: string) => Promise<unknown>;
+        ensureBuilderFeeRateCached?: (builderCode?: string) => Promise<void>;
+        resolveVersion?: (forceUpdate?: boolean) => Promise<number>;
+      };
+
+      rawClient.tokenConditionMap ??= {};
+      for (const tokenId of params.tokenIds) {
+        rawClient.tokenConditionMap[tokenId] = params.conditionId;
+        this.seedClobClientMarketMetadata(tokenId, {
+          tickSize: params.tickSize,
+          negRisk: params.negRisk,
+        });
+      }
+
+      const marketInfoStartedAt = Date.now();
+      if (rawClient.getClobMarketInfo) {
+        await rawClient.getClobMarketInfo(params.conditionId);
+      }
+      const marketInfoMs = Date.now() - marketInfoStartedAt;
+
+      const builderCode = this.config.builderCode !== undefined
+        ? this.config.builderCode
+        : readBuilderCodeOptional();
+      const builderFeeStartedAt = Date.now();
+      if (builderCode && rawClient.ensureBuilderFeeRateCached) {
+        await rawClient.ensureBuilderFeeRateCached(builderCode);
+      }
+      const builderFeeMs = Date.now() - builderFeeStartedAt;
+
+      const versionStartedAt = Date.now();
+      if (rawClient.resolveVersion) {
+        await rawClient.resolveVersion(false);
+      }
+      const versionMs = Date.now() - versionStartedAt;
+
+      const result = {
+        success: true,
+        conditionId: params.conditionId,
+        tokenCount: params.tokenIds.length,
+        latencyMs: Date.now() - startedAt,
+        marketInfoMs,
+        builderFeeMs,
+        versionMs,
+      };
+      this.diag.info('TradingService market metadata prepared', result);
+      return result;
+    } catch (error) {
+      const result = {
+        success: false,
+        conditionId: params.conditionId,
+        tokenCount: params.tokenIds.length,
+        latencyMs: Date.now() - startedAt,
+        errorMsg: error instanceof Error ? error.message : String(error),
+      };
+      this.diag.warn('TradingService market metadata prepare failed', result);
+      return result;
+    }
+  }
+
   // ============================================================================
   // Trading Helpers
   // ============================================================================
@@ -684,6 +776,7 @@ export class TradingService {
    * Market orders below this limit will be rejected by the API.
    */
   async createMarketOrder(params: MarketOrderParams): Promise<OrderResult> {
+    const startedAt = Date.now();
     // Validate minimum order value before sending to API
     if (params.amount < MIN_ORDER_VALUE_USDC) {
       return {
@@ -698,20 +791,23 @@ export class TradingService {
       tickSize: params.tickSize,
       negRisk: params.negRisk,
     });
+    const readyAt = Date.now();
 
     return this.rateLimiter.execute(ApiType.CLOB_API, async () => {
+      const rateLimiterReadyAt = Date.now();
       try {
         const [tickSize, negRisk] = await Promise.all([
           params.tickSize ?? this.getTickSize(params.tokenId),
           params.negRisk ?? this.isNegRisk(params.tokenId),
         ]);
+        const metadataReadyAt = Date.now();
 
         const orderType = params.orderType === 'FAK' ? ClobOrderType.FAK : ClobOrderType.FOK;
 
         // V2 UserMarketOrder: same `tokenID` / `side` / `amount` / `price`
         // surface; `feeRateBps` / `nonce` / `taker` removed; `builder` and
         // `metadata` populated by the SDK from `builderConfig`.
-        const result = await client.createAndPostMarketOrder(
+        const signedOrder = await client.createMarketOrder(
           {
             tokenID: params.tokenId,
             side: params.side === 'BUY' ? ClobSide.BUY : ClobSide.SELL,
@@ -719,8 +815,27 @@ export class TradingService {
             price: params.price,
           },
           { tickSize, negRisk },
-          orderType
         );
+        const signedAt = Date.now();
+        const result = await client.postOrder(signedOrder, orderType);
+        const postedAt = Date.now();
+
+        this.diag.info('TradingService market order latency', {
+          tokenId: params.tokenId.slice(0, 12),
+          side: params.side,
+          orderType: params.orderType ?? 'FOK',
+          amount: params.amount,
+          price: params.price,
+          preRateMs: readyAt - startedAt,
+          rateWaitMs: rateLimiterReadyAt - readyAt,
+          metadataMs: metadataReadyAt - rateLimiterReadyAt,
+          signAndBuildMs: signedAt - metadataReadyAt,
+          postOrderMs: postedAt - signedAt,
+          totalMs: postedAt - startedAt,
+          success: result.success === true,
+          status: result.status,
+          orderId: result.orderID ? result.orderID.slice(0, 12) : undefined,
+        });
 
         // FOK/FAK orders can return an orderID for a terminal no-fill/killed
         // response. Treating orderID alone as success creates ghost open orders

--- a/src/services/trading-service.ts
+++ b/src/services/trading-service.ts
@@ -87,6 +87,13 @@ function configureClobHttpKeepAlive(logger: Logger): void {
   });
 }
 
+function signatureTypeName(value: number | undefined): string {
+  if (value === SignatureTypeV2.POLY_GNOSIS_SAFE) return 'POLY_GNOSIS_SAFE';
+  if (value === SignatureTypeV2.POLY_1271) return 'POLY_1271';
+  if (value === SignatureTypeV2.EOA || value == null) return 'EOA';
+  return String(value);
+}
+
 // ============================================================================
 // Polymarket Order Minimums
 // ============================================================================
@@ -150,6 +157,17 @@ export interface TradingServiceConfig {
    * signature type to `POLY_GNOSIS_SAFE` (matches V1 behaviour).
    */
   safeAddress?: string;
+  /**
+   * Explicit CLOB wallet mode for non-Safe accounts. Builder/Safe remains the
+   * default when `safeAddress` is present. Deposit wallet mode signs with the
+   * owner EOA and uses the derived deposit wallet as maker/funder with
+   * POLY_1271 signatures.
+   */
+  walletMode?: 'builder_safe' | 'eoa' | 'deposit_wallet';
+  /** Explicit CLOB signature type override, used by deposit-wallet probes. */
+  signatureType?: number;
+  /** Explicit maker/funder address override, used by deposit-wallet probes. */
+  funderAddress?: string;
   /** Data API client — required for clearPosition() to fetch size internally */
   dataApi?: DataApiClient;
   /**
@@ -320,7 +338,7 @@ export interface OrderLatencyTelemetry {
 }
 
 export interface TradingServiceWalletIdentity {
-  walletMode: 'builder_safe' | 'eoa';
+  walletMode: 'builder_safe' | 'eoa' | 'deposit_wallet';
   maker: string;
   signer: string;
   funder?: string;
@@ -564,10 +582,12 @@ export class TradingService {
         ? this.config.builderCode
         : readBuilderCodeOptional();
 
-    // Builder mode: orders use Safe as maker, signed by EOA owner. In V2 the
-    // trigger is `safeAddress` set together with a builder code — HMAC creds
-    // are no longer involved in this branch.
-    const isBuilderMode = !!resolvedBuilderCode && !!this.config.safeAddress;
+    // Builder mode: orders use Safe as maker, signed by EOA owner. Deposit
+    // wallet mode signs with the owner EOA and uses the derived deposit wallet
+    // as maker/funder under POLY_1271.
+    const configuredWalletMode = this.resolveWalletMode(resolvedBuilderCode);
+    const funderAddress = this.resolveFunderAddress(configuredWalletMode);
+    const signatureType = this.resolveSignatureType(configuredWalletMode);
     const builderConfig = resolvedBuilderCode
       ? { builderCode: resolvedBuilderCode }
       : undefined;
@@ -606,8 +626,8 @@ export class TradingService {
         secret: this.credentials.secret,
         passphrase: this.credentials.passphrase,
       },
-      signatureType: isBuilderMode ? SignatureTypeV2.POLY_GNOSIS_SAFE : undefined,
-      funderAddress: isBuilderMode ? this.config.safeAddress : undefined,
+      signatureType,
+      funderAddress,
       builderConfig,
     });
     this.installClobFastPost(this.clobClient);
@@ -619,8 +639,9 @@ export class TradingService {
       builder_attribution: builderConfig?.builderCode === '0x0000000000000000000000000000000000000000000000000000000000000000'
         ? 'zero_no_rewards'
         : (builderConfig?.builderCode ? 'set' : 'absent'),
-      signature_type: isBuilderMode ? 'POLY_GNOSIS_SAFE' : 'EOA',
-      funder_address: this.config.safeAddress ?? '(EOA-self)',
+      signature_type: signatureTypeName(signatureType),
+      wallet_mode: configuredWalletMode,
+      funder_address: funderAddress ?? '(EOA-self)',
     });
 
     // PR-4: EIP-712 V2 domain echo (constants inlined for log clarity / drift detection).
@@ -683,16 +704,36 @@ export class TradingService {
     const builderCode = this.config.builderCode !== undefined
       ? this.config.builderCode
       : readBuilderCodeOptional();
-    const isBuilderMode = !!builderCode && !!this.config.safeAddress;
+    const walletMode = this.resolveWalletMode(builderCode);
     const signer = this.wallet.address;
+    const funder = this.resolveFunderAddress(walletMode);
     return {
-      walletMode: isBuilderMode ? 'builder_safe' : 'eoa',
-      maker: isBuilderMode ? this.config.safeAddress! : signer,
+      walletMode,
+      maker: funder ?? signer,
       signer,
-      funder: isBuilderMode ? this.config.safeAddress : undefined,
-      signatureType: isBuilderMode ? SignatureTypeV2.POLY_GNOSIS_SAFE : SignatureTypeV2.EOA,
+      funder,
+      signatureType: this.resolveSignatureType(walletMode),
       builderCode,
     };
+  }
+
+  private resolveWalletMode(builderCode?: string): 'builder_safe' | 'eoa' | 'deposit_wallet' {
+    if (this.config.walletMode) return this.config.walletMode;
+    if (builderCode && this.config.safeAddress) return 'builder_safe';
+    return 'eoa';
+  }
+
+  private resolveFunderAddress(walletMode: 'builder_safe' | 'eoa' | 'deposit_wallet'): string | undefined {
+    if (this.config.funderAddress) return this.config.funderAddress;
+    if (walletMode === 'builder_safe') return this.config.safeAddress;
+    return undefined;
+  }
+
+  private resolveSignatureType(walletMode: 'builder_safe' | 'eoa' | 'deposit_wallet'): number {
+    if (this.config.signatureType != null) return this.config.signatureType;
+    if (walletMode === 'builder_safe') return SignatureTypeV2.POLY_GNOSIS_SAFE;
+    if (walletMode === 'deposit_wallet') return SignatureTypeV2.POLY_1271;
+    return SignatureTypeV2.EOA;
   }
 
   private createPresignKey(kind: 'market' | 'limit', tokenId: string, orderType: string): string {

--- a/src/services/trading-service.ts
+++ b/src/services/trading-service.ts
@@ -154,6 +154,10 @@ export interface LimitOrderParams {
   expiration?: number;
   /** Market-specific minimum order size (from CLOB API). Falls back to MIN_ORDER_SIZE_SHARES if not provided. */
   minimumOrderSize?: number;
+  /** Optional hot-path metadata from WS/orderbook cache. Avoids REST /tick-size during order submission. */
+  tickSize?: TickSize;
+  /** Optional hot-path metadata from market cache. Avoids REST /neg-risk during order submission. */
+  negRisk?: boolean;
 }
 
 export interface MarketOrderParams {
@@ -162,6 +166,10 @@ export interface MarketOrderParams {
   amount: number;
   price?: number;
   orderType?: 'FOK' | 'FAK';
+  /** Optional hot-path metadata from WS/orderbook cache. Avoids REST /tick-size during order submission. */
+  tickSize?: TickSize;
+  /** Optional hot-path metadata from market cache. Avoids REST /neg-risk during order submission. */
+  negRisk?: boolean;
 }
 
 /** Parameters for clearing a token position (market sell) */
@@ -521,6 +529,27 @@ export class TradingService {
     return this.clobClient!;
   }
 
+  private seedClobClientMarketMetadata(
+    tokenId: string,
+    metadata: { tickSize?: TickSize; negRisk?: boolean },
+  ): void {
+    if (!this.clobClient) return;
+    const client = this.clobClient as unknown as {
+      tickSizes?: Record<string, TickSize>;
+      negRisk?: Record<string, boolean>;
+    };
+    if (metadata.tickSize) {
+      client.tickSizes ??= {};
+      client.tickSizes[tokenId] = metadata.tickSize;
+      this.tickSizeCache.set(tokenId, metadata.tickSize);
+    }
+    if (metadata.negRisk != null) {
+      client.negRisk ??= {};
+      client.negRisk[tokenId] = metadata.negRisk;
+      this.negRiskCache.set(tokenId, metadata.negRisk);
+    }
+  }
+
   // ============================================================================
   // Trading Helpers
   // ============================================================================
@@ -588,12 +617,16 @@ export class TradingService {
     // V2 attribution: every signed order MUST carry a builder code.
     this.ensureBuilderCode();
     const client = await this.ensureInitialized();
+    this.seedClobClientMarketMetadata(params.tokenId, {
+      tickSize: params.tickSize,
+      negRisk: params.negRisk,
+    });
 
     return this.rateLimiter.execute(ApiType.CLOB_API, async () => {
       try {
         const [tickSize, negRisk] = await Promise.all([
-          this.getTickSize(params.tokenId),
-          this.isNegRisk(params.tokenId),
+          params.tickSize ?? this.getTickSize(params.tokenId),
+          params.negRisk ?? this.isNegRisk(params.tokenId),
         ]);
 
         const orderType = params.orderType === 'GTD' ? ClobOrderType.GTD : ClobOrderType.GTC;
@@ -661,12 +694,16 @@ export class TradingService {
 
     this.ensureBuilderCode();
     const client = await this.ensureInitialized();
+    this.seedClobClientMarketMetadata(params.tokenId, {
+      tickSize: params.tickSize,
+      negRisk: params.negRisk,
+    });
 
     return this.rateLimiter.execute(ApiType.CLOB_API, async () => {
       try {
         const [tickSize, negRisk] = await Promise.all([
-          this.getTickSize(params.tokenId),
-          this.isNegRisk(params.tokenId),
+          params.tickSize ?? this.getTickSize(params.tokenId),
+          params.negRisk ?? this.isNegRisk(params.tokenId),
         ]);
 
         const orderType = params.orderType === 'FAK' ? ClobOrderType.FAK : ClobOrderType.FOK;
@@ -685,17 +722,16 @@ export class TradingService {
           orderType
         );
 
-        // FOK orders: clob-client may return orderID with success=undefined when order was
-        // accepted but not filled. Only trust explicit success=true.
-        // For non-FOK orders, having an orderID or transaction hash also indicates success.
+        // FOK/FAK orders can return an orderID for a terminal no-fill/killed
+        // response. Treating orderID alone as success creates ghost open orders
+        // and lets live strategies count killed FAK attempts as accepted orders.
+        // For immediate market orders, only explicit success=true means a fill
+        // path was accepted by CLOB.
         const isFokOrder = params.orderType !== 'FAK'; // default is FOK
-        // FOK: only trust explicit success=true (orderID alone means accepted-but-killed for FOK).
-        // FAK: orderID presence indicates success; transactionHashes alone is NOT a success signal.
-        const success = result.success === true ||
-          (!isFokOrder && result.success !== false && result.orderID !== undefined && result.orderID !== '');
+        const success = result.success === true;
 
         const errorMsg = !success
-          ? (result.errorMsg || `Market order ${isFokOrder ? 'FOK not filled' : 'rejected'} (status: ${result.status ?? 'unknown'}, orderID: ${result.orderID ?? 'none'})`)
+          ? (result.errorMsg || `Market order ${isFokOrder ? 'FOK not filled' : 'FAK killed/no-fill'} (status: ${result.status ?? 'unknown'}, orderID: ${result.orderID ?? 'none'})`)
           : result.errorMsg;
 
         return {

--- a/src/services/trading-service.ts
+++ b/src/services/trading-service.ts
@@ -725,7 +725,15 @@ export class TradingService {
 
   private resolveFunderAddress(walletMode: 'builder_safe' | 'eoa' | 'deposit_wallet'): string | undefined {
     if (this.config.funderAddress) return this.config.funderAddress;
-    if (walletMode === 'builder_safe') return this.config.safeAddress;
+    if (walletMode === 'builder_safe') {
+      if (!this.config.safeAddress) {
+        throw new Error('builder_safe wallet mode requires safeAddress or funderAddress');
+      }
+      return this.config.safeAddress;
+    }
+    if (walletMode === 'deposit_wallet') {
+      throw new Error('deposit_wallet wallet mode requires funderAddress');
+    }
     return undefined;
   }
 


### PR DESCRIPTION
## Summary
- Add `TradingService.presignMarketOrder` / `presignLimitOrder` to create signed payloads without posting.
- Add `postPresignedOrder` with single-use protection, existing CLOB result semantics, and presign latency telemetry.
- Export `PresignedOrder`, fingerprint, options, and wallet identity types.
- Add explicit wallet identity support for builder/Safe, EOA, and deposit-wallet modes.
- Add deposit-wallet/POLY_1271 identity handling: owner EOA signs, derived deposit wallet is maker/funder, and missing funder config is rejected instead of silently using the wrong maker.

## Parent PR / Evidence
- Parent Earning Engine PR: https://github.com/cyl19970726/let-me-try/pull/75
- Parent branch pins this submodule through commit `726bde3`.
- Real-order evidence in the parent PR covers builder/Safe FAK and FOK successful fills, plus blocked/no-spend EOA and deposit-wallet probes that prove the code path reaches CLOB but the selected account lacks the required balance/approval readiness.

## Tests
- `npm exec --yes pnpm@9 -- --filter @catalyst-team/poly-sdk test -- src/__tests__/unit/trading-service-presign.test.ts` → 5 tests passed.
- `npm exec --yes pnpm@9 -- --filter @catalyst-team/poly-sdk build`
